### PR TITLE
Use bytes type when building an array.

### DIFF
--- a/pytools/prefork.py
+++ b/pytools/prefork.py
@@ -76,7 +76,7 @@ def _recv_packet(sock, who="Process", partner="other end"):
 
     size, = unpack("I", size_bytes)
 
-    packet = ""
+    packet = b""
     while len(packet) < size:
         packet += sock.recv(size)
 


### PR DESCRIPTION
This should go part of the way to getting pytools Python 3 ready.
