### PR TITLE
Fixed exception when importing decorator in python 2.7

### DIFF
--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -38,6 +38,8 @@ try:
 except TypeError:
     # this must be Python 2.4
     my_decorator = decorator
+except ImportError:
+    my_decorator = decorator
 else:
     my_decorator = decorator_module.decorator
 


### PR DESCRIPTION
I had to make this change to pytools in order for pymbolic to work on my machine.
I'm not sure if TypeError was meant to catch the missing `level=` kwarg in Python 2.4 or a typo for ImportError.
