### PR TITLE
Require at least six 1.8.0 (for six.moves.intern)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(name="pytools",
       install_requires=[
           "decorator>=3.2.0",
           "appdirs>=1.4.0",
-          "six",
+          "six>=1.8.0",
           ],
 
       author="Andreas Kloeckner",


### PR DESCRIPTION
Since commit d855850c, function `six.moves.intern` is used in pytools,
but this function appeared only in six 1.8.0.
This commit prevents an error while importing pytools with an older six installed.

See: [six CHANGES](https://bitbucket.org/gutworth/six/src/1991f8b5b654f077e773f05695a08e0506b7367f/CHANGES?at=default&fileviewer=file-view-default)