### PR TITLE
Import numpy or skip for test_spatial_btree

### DIFF
--- a/test/test_pytools.py
+++ b/test/test_pytools.py
@@ -132,6 +132,7 @@ def test_memoize_keyfunc():
 
 @pytest.mark.parametrize("dims", [2, 3])
 def test_spatial_btree(dims, do_plot=False):
+    pytest.importorskip("numpy")
     import numpy as np
     nparticles = 2000
     x = -1 + 2*np.random.rand(dims, nparticles)


### PR DESCRIPTION
test_spatial_btree currently fails if numpy is not available.

test_p_convergence_verifier uses the pytest importorskip function to skip the test when numpy is not available.

This change does (adds) the same for test_spatial_btree.

Also, while it is noted that numpy was made an explicit dependency in https://github.com/inducer/pytools/commit/c15d5642bf460a53b990fb053457fc2e13e8241b, if numpy (given its large footprint and compiler/toolchain requirements) is not actually compulsory, or is only required for a few functions or methods in pytools, it would be great to make numpy an ```extras_require``` with a note/comment about what features require it.