### PR TITLE
[bugfix] Use base classes for ImmutableRecord in correct order

### DIFF
--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -207,7 +207,7 @@ class ImmutableRecordWithoutPickling(RecordWithoutPickling):
                     for field in self.__class__.fields))
 
 
-class ImmutableRecord(Record, ImmutableRecordWithoutPickling):
+class ImmutableRecord(ImmutableRecordWithoutPickling, Record):
     pass
 
 # }}}


### PR DESCRIPTION
A very weird bug: The order of base classes actually matters here,
because if __hash__ and __eq__ are defined in the wrong order,
__hash__ will get deleted (in 3). MWE:

```
class X(object):
    def __eq__(self, other):
        return True

class Y(object):
    def __hash__(self):
        return 0

class Z1(Y,X):
    pass

class Z2(X,Y):
    pass

hash(Z1())
hash(Z2())
```