### PR TITLE
add github-flavored markdown and aligned output for Table

### DIFF
--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -1513,6 +1513,21 @@ class Table:
         return "\n".join(lines)
 
     def github_markdown(self):
+        """Returns a string representation of the table formatted as
+        GitHub-Flavored Markdown.
+        https://docs.github.com/en/github/writing-on-github/organizing-information-with-tables
+
+        .. doctest ::
+
+            >>> tbl = Table(alignments=['l', 'r'])
+            >>> tbl.add_row([1, 2])
+            >>> tbl.add_row([10, 20])
+            >>> s = tbl.github_markdown().splitlines()
+            >>> assert s[0] == "1  |  2"
+            >>> assert s[1] == ":--|---:"
+            >>> assert s[2] == "10 | 20"
+
+        """
         columns = len(self.rows[0])
         col_widths = [max(len(row[i]) for row in self.rows)
                       for i in range(columns)]

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -1527,16 +1527,19 @@ class Table:
         .. doctest ::
 
             >>> tbl = Table(alignments=['l', 'r'])
-            >>> tbl.add_row([1, 2])
+            >>> tbl.add_row([1, '|'])
             >>> tbl.add_row([10, 20])
             >>> s = tbl.github_markdown().splitlines()
-            >>> assert s[0] == "1  |  2"
+            >>> assert s[0] == "1  | \|"
             >>> assert s[1] == ":--|---:"
             >>> assert s[2] == "10 | 20"
 
         """
-        columns = len(self.rows[0])
-        col_widths = [max(len(row[i]) for row in self.rows)
+        # Pipe symbols ('|') must be replaced
+        rows = [[w.replace('|', '\\|') for w in r] for r in self.rows]
+
+        columns = len(rows[0])
+        col_widths = [max(len(row[i]) for row in rows)
                       for i in range(columns)]
 
         alignments = self.alignments
@@ -1549,7 +1552,7 @@ class Table:
             else cell.ljust(col_width) if align == "l"
             else cell.rjust(col_width)
             for cell, col_width, align in zip(row, col_widths, alignments)])
-            for row in self.rows]
+            for row in rows]
         lines[1:1] = ["|".join(
             ":" + "-" * (col_width - 1 + (i > 0)) + ":" if align == "c"
             else ":" + "-" * (col_width + (i > 0)) if align == "l"

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -1546,8 +1546,8 @@ class Table:
 
     def github_markdown(self):
         """Returns a string representation of the table formatted as
-        GitHub-Flavored Markdown.
-        https://docs.github.com/en/github/writing-on-github/organizing-information-with-tables
+        `GitHub-Flavored Markdown.
+        <https://docs.github.com/en/github/writing-on-github/organizing-information-with-tables>`__
 
         .. doctest ::
 

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -1499,9 +1499,12 @@ class Table:
     .. automethod:: github_markdown
     """
 
-    def __init__(self, alignments=['l', 'r']):
+    def __init__(self, alignments=None):
         self.rows = []
-        self.alignments = alignments
+        if alignments is not None:
+            self.alignments = alignments
+        else:
+            self.alignments = ['l']
 
     def add_row(self, row):
         self.rows.append([str(i) for i in row])

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -1487,11 +1487,10 @@ class Table:
     """An ASCII table generator.
 
     :arg alignments: List of alignments of each column ('l', 'c', or 'r',
-        for left, center, and right alignment, respectively). Currently only used
-        by the `github_markdown` output formatter. Columns which have no alignment
-        specifier will use the last specified alignment. For example, with
-        `alignments=['l', 'r']`, the third and all following columns will use 'r'
-        alignment.
+        for left, center, and right alignment, respectively). Columns which
+        have no alignment specifier will use the last specified alignment. For
+        example, with `alignments=['l', 'r']`, the third and all following
+        columns will use 'r' alignment.
 
     .. automethod:: add_row
     .. automethod:: __str__

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -1522,13 +1522,15 @@ class Table:
         # last alignment specified:
         alignments += self.alignments[-1] * (columns - len(self.alignments))
 
-        lines = [" | ".join([cell.center(col_width) if align == 'c'
-            else cell.ljust(col_width) if align == 'l' else cell.rjust(col_width)
+        lines = [" | ".join([
+            cell.center(col_width) if align == "c"
+            else cell.ljust(col_width) if align == "l"
+            else cell.rjust(col_width)
             for cell, col_width, align in zip(row, col_widths, alignments)])
             for row in self.rows]
-        lines[1:1] = ["|".join(":" + "-" * (col_width - 1 + (i > 0)) + ":"
-            if align == 'c'
-            else ':' + "-" * (col_width + (i > 0)) if align == 'l'
+        lines[1:1] = ["|".join(
+            ":" + "-" * (col_width - 1 + (i > 0)) + ":" if align == "c"
+            else ":" + "-" * (col_width + (i > 0)) if align == "l"
             else "-" * (col_width + (i > 0)) + ":"
             for i, (col_width, align) in enumerate(zip(col_widths, alignments)))]
 

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -1530,7 +1530,7 @@ class Table:
             >>> tbl.add_row([1, '|'])
             >>> tbl.add_row([10, 20])
             >>> s = tbl.github_markdown().splitlines()
-            >>> assert s[0] == "1  | \|"
+            >>> assert s[0] == "1  | \\|"
             >>> assert s[1] == ":--|---:"
             >>> assert s[2] == "10 | 20"
 

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -1489,10 +1489,12 @@ class Table:
     .. automethod:: add_row
     .. automethod:: __str__
     .. automethod:: latex
+    .. automethod:: github_markdown
     """
 
-    def __init__(self):
+    def __init__(self, alignments=['l', 'r']):
         self.rows = []
+        self.alignments = alignments
 
     def add_row(self, row):
         self.rows.append([str(i) for i in row])
@@ -1507,6 +1509,28 @@ class Table:
             for row in self.rows]
         lines[1:1] = ["+".join("-" * (col_width + 1 + (i > 0))
             for i, col_width in enumerate(col_widths))]
+
+        return "\n".join(lines)
+
+    def github_markdown(self):
+        columns = len(self.rows[0])
+        col_widths = [max(len(row[i]) for row in self.rows)
+                      for i in range(columns)]
+
+        alignments = self.alignments
+        # If not all alignments were specified, extend alignments with the
+        # last alignment specified:
+        alignments += self.alignments[-1] * (columns - len(self.alignments))
+
+        lines = [" | ".join([cell.center(col_width) if align == 'c'
+            else cell.ljust(col_width) if align == 'l' else cell.rjust(col_width)
+            for cell, col_width, align in zip(row, col_widths, alignments)])
+            for row in self.rows]
+        lines[1:1] = ["|".join(":" + "-" * (col_width - 1 + (i > 0)) + ":"
+            if align == 'c'
+            else ':' + "-" * (col_width + (i > 0)) if align == 'l'
+            else "-" * (col_width + (i > 0)) + ":"
+            for i, (col_width, align) in enumerate(zip(col_widths, alignments)))]
 
         return "\n".join(lines)
 

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -1486,6 +1486,13 @@ a_star = MovedFunctionDeprecationWrapper(a_star_moved)
 class Table:
     """An ASCII table generator.
 
+    :arg alignments: List of alignments of each column ('l', 'c', or 'r',
+        for left, center, and right alignment, respectively). Currently only used
+        by the `github_markdown` output formatter. Columns which have no alignment
+        specifier will use the last specified alignment. For example, with
+        `alignments=['l', 'r']`, the third and all following columns will use 'r'
+        alignment.
+
     .. automethod:: add_row
     .. automethod:: __str__
     .. automethod:: latex


### PR DESCRIPTION
See https://docs.github.com/en/github/writing-on-github/organizing-information-with-tables
for specification.

- Outputs a table that is a valid GFM table, and gets rendered automatically as a table on GitHub.
- Adds column alignment specification and makes output respect it.