### PR TITLE
Escape backslashes in Table documentation

### DIFF
--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -1614,9 +1614,9 @@ class Table:
             >>> tbl.add_row([1, '|'])
             >>> tbl.add_row([10, '20||'])
             >>> print(tbl.github_markdown())
-            1  |     \|
+            1  |     \\|
             :--|-------:
-            10 | 20\|\|
+            10 | 20\\|\\|
 
         """  # noqa: W605
         # Pipe symbols ('|') must be replaced


### PR DESCRIPTION
Sequence of symbols `\|` is an invalid escape sequence in Python and may cause syntax warning or syntax error in certain Python versions. An example of that is a failing test here:
https://gitlab.com/quantumsim/quantumsim/-/jobs/869297979
This PR escapes these backslashes in docstring, that fixes the error above, as it happens in this pipeline:
https://gitlab.com/quantumsim/quantumsim/-/jobs/875855857