### PR TITLE
Unordered hashing

### DIFF
--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -2632,6 +2632,11 @@ def unordered_hash(hash_constructor, iterable):
     for i in iterable:
         h_i = hash_constructor()
         h_i.update(i)
+        # Using sys.byteorder (for efficiency) here technically makes the
+        # hash system-dependent (which it should not be), however the
+        # effect of this is undone by the to_bytes conversion below, while
+        # left invariant by the intervening XOR operations (which do not
+        # mix adjacent bits).
         h_int = h_int ^ int.from_bytes(h_i.digest(), sys.byteorder)
 
     h = hash_constructor()

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -2623,7 +2623,7 @@ def resolve_name(name):
 
 # {{{ unordered_hash
 
-def unordered_hash(hash_constructor, iterable):
+def unordered_hash(hash_instance, iterable, hash_constructor=None):
     """Using a hash algorithm given by the parameter-less constructor
     *hash_constructor*, return a hash object whose internal state
     depends on the entries of *iterable*, but not their order. If *hash*
@@ -2631,6 +2631,10 @@ def unordered_hash(hash_constructor, iterable):
     the each entry *i* of the iterable must permit ``hash.upate(i)`` to
     succeed. An example of *hash_constructor* is ``hashlib.sha256``
     from :mod:`hashlib`.  ``hash.digest_size`` must also be defined.
+    If *hash_constructor* is not provided, ``hash_instance.name`` is
+    used to deduce it.
+
+    :returns: the updated *hash_instance*.
 
     .. warning::
 
@@ -2639,6 +2643,12 @@ def unordered_hash(hash_constructor, iterable):
 
     .. versionadded:: 2021.2
     """
+
+    if hash_constructor is None:
+        from functools import partial
+        import hashlib
+        hash_constructor = partial(hashlib.new, hash_instance.name)
+
     h_int = 0
     for i in iterable:
         h_i = hash_constructor()
@@ -2650,9 +2660,8 @@ def unordered_hash(hash_constructor, iterable):
         # mix adjacent bits).
         h_int = h_int ^ int.from_bytes(h_i.digest(), sys.byteorder)
 
-    h = hash_constructor()
-    h.update(h_int.to_bytes(h.digest_size, sys.byteorder))
-    return h
+    hash_instance.update(h_int.to_bytes(hash_instance.digest_size, sys.byteorder))
+    return hash_instance
 
 # }}}
 

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -2618,8 +2618,8 @@ def unordered_hash(hash_constructor, iterable):
     depends on the entries of *iterable*, but not their order. If *hash*
     is the instance returned by evaluating ``hash_constructor()``, then
     the each entry *i* of the iterable must permit ``hash.upate(i)`` to
-    succeed. An example of *hash_constructor* is :class:`hashlib.sha256`.
-    ``hash.digest_size`` must also be defined.
+    succeed. An example of *hash_constructor* is ``hashlib.sha256``
+    from :mod:`hashlib`.  ``hash.digest_size`` must also be defined.
 
     .. warning::
 

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -169,6 +169,11 @@ Backports of newer Python functionality
 
 .. autofunction:: resolve_name
 
+Hashing
+-------
+
+.. autofunction:: unordered_hash
+
 Type Variables Used
 -------------------
 
@@ -2601,6 +2606,37 @@ def resolve_name(name):
     for p in parts:
         result = getattr(result, p)
     return result
+
+# }}}
+
+
+# {{{ unordered_hash
+
+def unordered_hash(hash_constructor, iterable):
+    """Using a hash algorithm given by the parameter-less constructor
+    *hash_constructor*, return a hash object whose internal state
+    depends on the entries of *iterable*, but not their order. If *hash*
+    is the instance returned by evaluating ``hash_constructor()``, then
+    the each entry *i* of the iterable must permit ``hash.upate(i)`` to
+    succeed. An example of *hash_constructor* is :class:`hashlib.sha256`.
+    ``hash.digest_size`` must also be defined.
+
+    .. warning::
+
+        The construction used in this function is likely not cryptographically
+        secure. Do not use this function in a security-relevant context.
+
+    .. versionadded:: 2021.2
+    """
+    h_int = 0
+    for i in iterable:
+        h_i = hash_constructor()
+        h_i.update(i)
+        h_int = h_int ^ int.from_bytes(h_i.digest(), sys.byteorder)
+
+    h = hash_constructor()
+    h.update(h_int.to_bytes(h.digest_size, sys.byteorder))
+    return h
 
 # }}}
 

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -173,6 +173,10 @@ class ItemDirManager(CleanupBase):
 # {{{ key generation
 
 class KeyBuilder:
+    # this exists so that we can (conceivably) switch algorithms at some point
+    # down the road
+    new_hash = hashlib.sha256
+
     def rec(self, key_hash, key):
         digest = None
 
@@ -187,7 +191,7 @@ class KeyBuilder:
             except AttributeError:
                 pass
             else:
-                inner_key_hash = hashlib.sha256()
+                inner_key_hash = self.new_hash()
                 method(inner_key_hash, self)
                 digest = inner_key_hash.digest()
 
@@ -205,7 +209,7 @@ class KeyBuilder:
                         method = self.update_for_specific_dtype
 
             if method is not None:
-                inner_key_hash = hashlib.sha256()
+                inner_key_hash = self.new_hash()
                 method(inner_key_hash, key)
                 digest = inner_key_hash.digest()
 
@@ -224,7 +228,7 @@ class KeyBuilder:
         key_hash.update(digest)
 
     def __call__(self, key):
-        key_hash = hashlib.sha256()
+        key_hash = self.new_hash()
         self.rec(key_hash, key)
         return key_hash.hexdigest()
 

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -173,6 +173,22 @@ class ItemDirManager(CleanupBase):
 # {{{ key generation
 
 class KeyBuilder:
+    """A (stateless) object that computes hashes of objects fed to it. Subclassing
+    this class permits customizing the computation of hash keys.
+
+    .. automethod:: __call__
+    .. automethod:: rec
+    .. staticmethod:: new_hash()
+
+        Return a new hash instance following the protocol of the ones
+        from :mod:`hashlib`. This will permit switching to different
+        hash algorithms in the future. Subclasses are expected to use
+        this to create new hashes. Not doing so is deprecated and
+        may stop working as early as 2022.
+
+        .. versionadded:: 2021.1.3
+    """
+
     # this exists so that we can (conceivably) switch algorithms at some point
     # down the road
     new_hash = hashlib.sha256

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -186,7 +186,7 @@ class KeyBuilder:
         this to create new hashes. Not doing so is deprecated and
         may stop working as early as 2022.
 
-        .. versionadded:: 2021.1.3
+        .. versionadded:: 2021.2
     """
 
     # this exists so that we can (conceivably) switch algorithms at some point

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -294,11 +294,9 @@ class KeyBuilder:
     def update_for_frozenset(self, key_hash, key):
         from pytools import unordered_hash
 
-        self.rec(key_hash,
-                unordered_hash(
-                    self.new_hash,
-                    (self.rec(self.new_hash(), key_i).digest() for key_i in key)
-                    ).digest())
+        unordered_hash(
+            key_hash,
+            (self.rec(self.new_hash(), key_i).digest() for key_i in key))
 
     @staticmethod
     def update_for_NoneType(key_hash, key):  # noqa

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -194,6 +194,16 @@ class KeyBuilder:
     new_hash = hashlib.sha256
 
     def rec(self, key_hash, key):
+        """
+        :arg key_hash: the hash object to be updated with the hash of *key*.
+        :arg key: the (immutable) Python object to be hashed.
+        :returns: the updated *key_hash*
+
+        .. versionchanged:: 2021.2
+
+            Now returns the updated *key_hash*.
+        """
+
         digest = None
 
         try:
@@ -242,6 +252,7 @@ class KeyBuilder:
                 pass
 
         key_hash.update(digest)
+        return key_hash
 
     def __call__(self, key):
         key_hash = self.new_hash()

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -263,14 +263,21 @@ class KeyBuilder:
 
     @staticmethod
     def update_for_int(key_hash, key):
-        key_hash.update(str(key).encode("utf8"))
+        sz = 8
+        while True:
+            try:
+                key_hash.update(key.to_bytes(sz, byteorder="little", signed=True))
+                return
+            except OverflowError:
+                sz *= 2
 
-    update_for_long = update_for_int
-    update_for_bool = update_for_int
+    @staticmethod
+    def update_for_bool(key_hash, key):
+        key_hash.update(str(key).encode("utf8"))
 
     @staticmethod
     def update_for_float(key_hash, key):
-        key_hash.update(repr(key).encode("utf8"))
+        key_hash.update(key.hex().encode("utf8"))
 
     @staticmethod
     def update_for_str(key_hash, key):

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -292,8 +292,13 @@ class KeyBuilder:
             self.rec(key_hash, obj_i)
 
     def update_for_frozenset(self, key_hash, key):
-        for set_key in sorted(key):
-            self.rec(key_hash, set_key)
+        from pytools import unordered_hash
+
+        self.rec(key_hash,
+                unordered_hash(
+                    self.new_hash,
+                    (self.rec(self.new_hash(), key_i).digest() for key_i in key)
+                    ).digest())
 
     @staticmethod
     def update_for_NoneType(key_hash, key):  # noqa

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -469,7 +469,7 @@ class _PersistentDictBase:
             import appdirs
             container_dir = join(
                     appdirs.user_cache_dir("pytools", "pytools"),
-                    "pdict-v3-{}-py{}".format(
+                    "pdict-v4-{}-py{}".format(
                         identifier,
                         ".".join(str(i) for i in sys.version_info)))
 

--- a/pytools/version.py
+++ b/pytools/version.py
@@ -1,3 +1,3 @@
-VERSION = (2021, 1, 2)
+VERSION = (2021, 2)
 VERSION_STATUS = ""
 VERSION_TEXT = ".".join(str(x) for x in VERSION) + VERSION_STATUS

--- a/test/test_persistent_dict.py
+++ b/test/test_persistent_dict.py
@@ -58,7 +58,8 @@ def test_persistent_dict_storage_and_lookup():
                     for i in range(n))
 
         keys = [
-                (randrange(2000), rand_str(), None, SomeTag(rand_str()))
+                (randrange(2000)-1000, rand_str(), None, SomeTag(rand_str()),
+                    frozenset({"abc", 123}))
                 for i in range(20)]
         values = [randrange(2000) for i in range(20)]
 

--- a/test/test_pytools.py
+++ b/test/test_pytools.py
@@ -446,15 +446,15 @@ def test_unordered_hash():
     random.shuffle(lst)
 
     from pytools import unordered_hash
-    assert (unordered_hash(hashlib.sha256, lorig).digest()
-            == unordered_hash(hashlib.sha256, lst).digest())
-    assert (unordered_hash(hashlib.sha256, lorig).digest()
-            == unordered_hash(hashlib.sha256, lorig).digest())
-    assert (unordered_hash(hashlib.sha256, lorig).digest()
-            != unordered_hash(hashlib.sha256, lorig[:-1]).digest())
+    assert (unordered_hash(hashlib.sha256(), lorig).digest()
+            == unordered_hash(hashlib.sha256(), lst).digest())
+    assert (unordered_hash(hashlib.sha256(), lorig).digest()
+            == unordered_hash(hashlib.sha256(), lorig).digest())
+    assert (unordered_hash(hashlib.sha256(), lorig).digest()
+            != unordered_hash(hashlib.sha256(), lorig[:-1]).digest())
     lst[0] = b"aksdjfla;sdfjafd"
-    assert (unordered_hash(hashlib.sha256, lorig).digest()
-            != unordered_hash(hashlib.sha256, lst).digest())
+    assert (unordered_hash(hashlib.sha256(), lorig).digest()
+            != unordered_hash(hashlib.sha256(), lst).digest())
 
 
 if __name__ == "__main__":

--- a/test/test_pytools.py
+++ b/test/test_pytools.py
@@ -370,6 +370,26 @@ def test_tag():
         t4.without_tags(red_ribbon)
 
 
+def test_unordered_hash():
+    import random
+    import hashlib
+
+    lst = [random.randbytes(20) for _ in range(200)]
+    lorig = lst[:]
+    random.shuffle(lst)
+
+    from pytools import unordered_hash
+    assert (unordered_hash(hashlib.sha256, lorig).digest()
+            == unordered_hash(hashlib.sha256, lst).digest())
+    assert (unordered_hash(hashlib.sha256, lorig).digest()
+            == unordered_hash(hashlib.sha256, lorig).digest())
+    assert (unordered_hash(hashlib.sha256, lorig).digest()
+            != unordered_hash(hashlib.sha256, lorig[:-1]).digest())
+    lst[0] = b"aksdjfla;sdfjafd"
+    assert (unordered_hash(hashlib.sha256, lorig).digest()
+            != unordered_hash(hashlib.sha256, lst).digest())
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])

--- a/test/test_pytools.py
+++ b/test/test_pytools.py
@@ -1,3 +1,26 @@
+__copyright__ = "Copyright (C) 2009-2021 Andreas Kloeckner"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+
 import sys
 import pytest
 

--- a/test/test_pytools.py
+++ b/test/test_pytools.py
@@ -397,7 +397,9 @@ def test_unordered_hash():
     import random
     import hashlib
 
-    lst = [random.randbytes(20) for _ in range(200)]
+    # FIXME: Use randbytes once >=3.9 is OK
+    lst = [bytes([random.randrange(256) for _ in range(20)])
+            for _ in range(200)]
     lorig = lst[:]
     random.shuffle(lst)
 


### PR DESCRIPTION
@kaushikcfd would you mind taking a look? This addresses the inability to do `sorted()` for frozenset/dict hashing when those contain `Tag` et al. in https://github.com/inducer/loopy/pull/245.

cc @nchristensen 