### PR TITLE
Drop autodoc_typehints from sphinx config

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,4 +68,3 @@ intersphinx_mapping = {
     }
 
 autoclass_content = "class"
-autodoc_typehints = "description"


### PR DESCRIPTION
https://github.com/inducer/modepy/pull/38#issuecomment-846472970