### PR TITLE
make Taggable.copy an abstractmethod

### DIFF
--- a/pytools/tag.py
+++ b/pytools/tag.py
@@ -27,6 +27,7 @@ Internal stuff that is only here because the documentation tool wants it
 from dataclasses import dataclass
 from typing import Tuple, Set, Any, FrozenSet, Union, Iterable, TypeVar
 from pytools import memoize
+from abc import ABC, abstractmethod
 
 __copyright__ = """
 Copyright (C) 2020 Andreas Klöckner
@@ -222,7 +223,7 @@ def normalize_tags(tags: TagOrIterableType) -> TagsType:
 
 # {{{ taggable
 
-class Taggable:
+class Taggable(ABC):
     """
     Parent class for objects with a `tags` attribute.
 
@@ -255,12 +256,12 @@ class Taggable:
         """
         self.tags = tags
 
+    @abstractmethod
     def copy(self: T_co, **kwargs: Any) -> T_co:
         """
         Returns of copy of *self* with the specified tags. This method
         should be overridden by subclasses.
         """
-        raise NotImplementedError("The copy function is not implemented.")
 
     def tagged(self: T_co, tags: TagOrIterableType) -> T_co:
         """


### PR DESCRIPTION
This should have helped catch some errors in [Pytato](https://github.com/inducer/pytato), as the taggable-type didn't have a `.copy` defined.

Draft because:
- [x] Needs https://github.com/inducer/pytato/pull/125 (?)
- [x]  Needs https://github.com/inducer/loopy/pull/467 