### PR TITLE
Allow choosing table type in EOCRecorder

### DIFF
--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -1695,11 +1695,29 @@ class Table:
         return output.getvalue().rstrip(csv_kwargs["lineterminator"])
 
     def latex(self, skip_lines=0, hline_after=None):
+        r"""Returns a string containing the rows of a LaTeX representation of
+        the table.
+
+        :arg skip_lines: number of lines to skip at the start of the table.
+        :arg hline_after: list of row indices after which to add an ``hline``
+            (the indices must subtract *skip_lines*, if non-zero).
+
+        .. doctest::
+
+            >>> tbl = Table()
+            >>> tbl.add_row([0, "skipped"])
+            >>> tbl.add_row([1, "apple"])
+            >>> tbl.add_row([2, "pear"])
+            >>> print(tbl.latex(skip_lines=1))
+            1 & apple \\
+            2 & pear \\
+        """
         if hline_after is None:
             hline_after = []
+
         lines = []
         for row_nr, row in enumerate(self.rows[skip_lines:]):
-            lines.append(f"{' & '.join(row)} \\")
+            lines.append(fr"{' & '.join(row)} \\")
             if row_nr in hline_after:
                 lines.append(r"\hline")
 

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -1569,8 +1569,9 @@ class Table:
 
     .. automethod:: add_row
     .. automethod:: __str__
-    .. automethod:: latex
     .. automethod:: github_markdown
+    .. automethod:: csv
+    .. automethod:: latex
     """
 
     def __init__(self, alignments=None):
@@ -1697,8 +1698,8 @@ class Table:
         if hline_after is None:
             hline_after = []
         lines = []
-        for row_nr, row in list(enumerate(self.rows))[skip_lines:]:
-            lines.append(" & ".join(row)+r" \\")
+        for row_nr, row in enumerate(self.rows[skip_lines:]):
+            lines.append(f"{' & '.join(row)} \\")
             if row_nr in hline_after:
                 lines.append(r"\hline")
 

--- a/pytools/convergence.py
+++ b/pytools/convergence.py
@@ -52,7 +52,7 @@ class EOCRecorder:
     def max_error(self):
         return max(err for absc, err in self.history)
 
-    def pretty_print(self,
+    def _to_table(self, *,
             abscissa_label="h",
             error_label="Error",
             gliding_mean=2,
@@ -75,11 +75,39 @@ class EOCRecorder:
 
             tbl.add_row((absc_str, err_str, eoc_str))
 
+        return tbl
+
+    def pretty_print(self, *,
+            abscissa_label="h",
+            error_label="Error",
+            gliding_mean=2,
+            abscissa_format="%s",
+            error_format="%s",
+            eoc_format="%s",
+            table_type="markdown"):
+        tbl = self._to_table(
+                abscissa_label=abscissa_label, error_label=error_label,
+                abscissa_format=abscissa_format,
+                error_format=error_format,
+                eoc_format=eoc_format,
+                gliding_mean=gliding_mean)
+
+        if table_type == "markdown":
+            tbl_str = tbl.github_markdown()
+        elif table_type == "latex":
+            tbl_str = tbl.latex()
+        elif table_type == "ascii":
+            tbl_str = str(tbl)
+        elif table_type == "csv":
+            tbl_str = tbl.csv()
+        else:
+            raise ValueError(f"unknown table type: {table_type}")
+
         if len(self.history) > 1:
-            return "{}\n\nOverall EOC: {}".format(str(tbl),
+            return "{}\n\nOverall EOC: {}".format(tbl_str,
                     self.estimate_order_of_convergence()[0, 1])
         else:
-            return str(tbl)
+            return tbl_str
 
     def __str__(self):
         return self.pretty_print()


### PR DESCRIPTION
Set the default to `markdown` instead of the previous `ascii` since the tables look pretty much the same and this is easier to copy paste in here.