### PR TITLE
Prefer platformdirs to appdirs if available

### DIFF
--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -464,7 +464,11 @@ class _PersistentDictBase:
 
         from os.path import join
         if container_dir is None:
-            import appdirs
+            try:
+                import platformdirs as appdirs
+            except ImportError:
+                import appdirs
+
             container_dir = join(
                     appdirs.user_cache_dir("pytools", "pytools"),
                     "pdict-v4-{}-py{}".format(

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name="pytools",
       python_requires="~=3.6",
 
       install_requires=[
-          "appdirs>=1.4.0",
+          "platformdirs>=2.2.0",
           "numpy>=1.6.0",
           "dataclasses>=0.7;python_version<='3.6'"
           ],


### PR DESCRIPTION
Seems to be the prefered maintained alternative these days (see https://github.com/psf/black/pull/2375). Not quite sure what do to in `setup.py` though. Just replace `appdirs` with `plaformdirs` in `install_requires`?

For context, for some reason `appdirs` disappeared from my venv on porter (likely due to `--system-site-packages`) and `platformdirs` was there.