### PR TITLE
Remove a spurious warning.

### DIFF
--- a/pytools/prefork.py
+++ b/pytools/prefork.py
@@ -88,9 +88,6 @@ def _recv_packet(sock, who="Process", partner="other end"):
     size_bytes = sock.recv(size_bytes_size)
 
     if len(size_bytes) < size_bytes_size:
-        from warnings import warn
-        warn(f"{who} exiting upon apparent death of {partner}")
-
         raise SystemExit
 
     size, = unpack("I", size_bytes)


### PR DESCRIPTION
This warning has been confusing our users for a while as when our main process dies due to a SEGFAULT this warning gets printed, leading to users believing this is the issue.  As is, the warning does not add much utility, so this PR simply removes it and has the process terminate gracefully.