### PR TITLE
Add table merging

### DIFF
--- a/pytools/convergence.py
+++ b/pytools/convergence.py
@@ -99,6 +99,10 @@ class EOCRecorder:
 
             tbl.add_row((absc_str, err_str, eoc_str))
 
+        if len(self.history) > 1:
+            order = self.estimate_order_of_convergence()[0, 1]
+            tbl.add_row(("Overall", "", eoc_format % order))
+
         return tbl
 
     def pretty_print(self, *,
@@ -115,10 +119,6 @@ class EOCRecorder:
                 error_format=error_format,
                 eoc_format=eoc_format,
                 gliding_mean=gliding_mean)
-
-        if len(self.history) > 1:
-            order = self.estimate_order_of_convergence()[0, 1]
-            tbl.add_row(("Overall", "", eoc_format % order))
 
         if table_type == "markdown":
             return tbl.github_markdown()
@@ -144,6 +144,49 @@ class EOCRecorder:
         outfile.write("\n")
         for absc, _err in self.history:
             outfile.write(f"{absc:f} {const * absc**(-order):f}\n")
+
+
+def stringify_eocs(*eocs: EOCRecorder,
+        names: Optional[Tuple[str, ...]] = None,
+        abscissa_label: str = "h",
+        error_label: str = "Error",
+        gliding_mean: int = 2,
+        abscissa_format: str = "%s",
+        error_format: str = "%s",
+        eoc_format: str = "%s",
+        table_type: str = "markdown") -> str:
+    """
+    :arg names: a :class:`tuple` of names to use for the *error_label* of each
+        *eoc*.
+    """
+    if names is not None and len(names) < len(eocs):
+        raise ValueError(
+                f"insufficient names: got {len(names)} names for "
+                f"{len(eocs)} EOCRecorder instances")
+
+    if names is None:
+        names = tuple([f"{error_label} {i}" for i in range(len(eocs))])
+
+    from pytools import merge_tables
+    tbl = merge_tables(*[eoc._to_table(
+        abscissa_label=abscissa_label, error_label=name,
+        abscissa_format=abscissa_format,
+        error_format=error_format,
+        eoc_format=eoc_format,
+        gliding_mean=gliding_mean)
+        for name, eoc in zip(names, eocs)
+        ], skip_columns=(0,))
+
+    if table_type == "markdown":
+        return tbl.github_markdown()
+    elif table_type == "latex":
+        return tbl.latex()
+    elif table_type == "ascii":
+        return str(tbl)
+    elif table_type == "csv":
+        return tbl.csv()
+    else:
+        raise ValueError(f"unknown table type: {table_type}")
 
 # }}}
 

--- a/test/test_pytools.py
+++ b/test/test_pytools.py
@@ -308,6 +308,14 @@ def test_table():
     print()
     print(tbl.latex())
 
+    # {{{ test merging
+
+    from pytools import merge_tables
+    tbl = merge_tables(tbl, tbl, tbl, skip_columns=(0,))
+    print(tbl.github_markdown())
+
+    # }}}
+
 
 def test_eoc():
     from pytools.convergence import EOCRecorder
@@ -326,6 +334,14 @@ def test_eoc():
             abscissa_format="%.5e",
             error_format="%.5e",
             eoc_format="%5.2f")
+    print(p)
+
+    # }}}
+
+    # {{{ test merging
+
+    from pytools.convergence import stringify_eocs
+    p = stringify_eocs(eoc, eoc, eoc, names=("First", "Second", "Third"))
     print(p)
 
     # }}}


### PR DESCRIPTION
This adds a couple of things:
* type annotations to `Table`
* adds some checks when adding rows to the table.
* removes some duplication in getting alignements and column widths in the table stringifiers.
* adds a `merge_tables` that takes a bunch of tables and returns a single table with all the columns concatenated
* uses that to implement a `stringify_eocs` that merges a bunch of `EOCRecorders` into a single table.

