### PR TITLE
Fix type names in `pytools.tag`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,3 +30,8 @@ intersphinx_mapping = {
     "https://documen.tician.de/pymbolic/": None,
     "https://documen.tician.de/loopy/": None,
     }
+
+
+nitpick_ignore_regex = [
+        ["py:class", r"typing_extensions\.(.+)"],
+        ]

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(name="pytools",
       install_requires=[
           "platformdirs>=2.2.0",
           "numpy>=1.6.0",
-          "dataclasses>=0.7;python_version<='3.6'"
+          "dataclasses>=0.7;python_version<='3.6'",
+          "typing_extensions; python_version<'3.11'",
           ],
 
       package_data={"pytools": ["py.typed"]},


### PR DESCRIPTION
Upon reviewing https://github.com/inducer/arraycontext/pull/154, I found myself very much not loving the type names I was looking at. @alexfikl, could you take a look if this seems sane? (I'll do a pytools release once some version of this is in.)