### PR TITLE
Tighten typing_extensions version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name="pytools",
           "platformdirs>=2.2.0",
           "numpy>=1.6.0",
           "dataclasses>=0.7;python_version<='3.6'",
-          "typing_extensions; python_version<'3.11'",
+          "typing_extensions>=4.0; python_version<'3.11'",
           ],
 
       package_data={"pytools": ["py.typed"]},


### PR DESCRIPTION
Needs a version that includes the `Self` type.