### PR TITLE
add WeakUniqueTag

### DIFF
--- a/pytools/tag.py
+++ b/pytools/tag.py
@@ -7,6 +7,7 @@ Tag Interface
 .. autoclass:: Taggable
 .. autoclass:: Tag
 .. autoclass:: UniqueTag
+.. autoclass:: WeakUniqueTag
 
 Supporting Functionality
 ------------------------

--- a/pytools/tag.py
+++ b/pytools/tag.py
@@ -322,7 +322,7 @@ class Taggable:
         """
         return self._with_new_tags(
                 tags=check_tag_uniqueness(
-                    list(self.tags)+list(normalize_tags(list(tags)))))
+                    list(self.tags) + list(normalize_tags(tags))))
 
     def without_tags(self,
             tags: ToTagSetConvertible, verify_existence: bool = True) -> Self:

--- a/pytools/tag.py
+++ b/pytools/tag.py
@@ -212,7 +212,7 @@ def check_tag_uniqueness(tags: List[Tag]) -> FrozenSet[Tag]:
     raise :exc:`NonUniqueTagError`. If any *tags* are not
     subclasses of :class:`Tag`, a :exc:`TypeError` will be raised.
 
-    :returns: *tags* with duplicate instance of :class:`WeakUniqueTag` removed.
+    :returns: *tags* with duplicate instances of :class:`WeakUniqueTag` removed.
     """
     unique_tag_descendants: Set[Tag] = set()
     weak_unique_tag_descendants: Set[Tag] = set()
@@ -322,7 +322,7 @@ class Taggable:
         """
         return self._with_new_tags(
                 tags=check_tag_uniqueness(
-                    list(self.tags)+list(normalize_tags(tags))))
+                    list(self.tags)+list(normalize_tags(list(tags)))))
 
     def without_tags(self,
             tags: ToTagSetConvertible, verify_existence: bool = True) -> Self:

--- a/test/test_pytools.py
+++ b/test/test_pytools.py
@@ -688,7 +688,6 @@ def test_weakuniquetag():
     wu1 = wu1.tagged([Wu1(1), Wu1(2)])
 
     assert len(wu1.tags) == 1
-    assert list(wu1.tags)[0].myid == 1
 
     wu2 = TaggableWithNewTags(Wu1(1))
 

--- a/test/test_pytools.py
+++ b/test/test_pytools.py
@@ -689,9 +689,9 @@ def test_weakuniquetag():
 
     assert len(wu1.tags) == 1
 
-    wu2 = TaggableWithNewTags(Wu1(1))
+    wu2 = TaggableWithNewTags(frozenset((Wu1(1),)))
 
-    wu2 = wu1.tagged([Wu1(11), Wu2(22), Wu3(33)])
+    wu2 = wu2.tagged([Wu1(11), Wu2(22), Wu3(33)])
 
     assert len(wu2.tags) == 2
     assert list(wu2.tags)[0].myid == 1


### PR DESCRIPTION
WeakUniqueTag - A tag that can be only set once, subsequent attempts to add a tag instance of the same subclass will be silently ignored (in contrast to UniqueTag, which raises an exception)

This might make code such as https://github.com/inducer/meshmode/pull/329 cleaner.