### PR TITLE
Install numpy for pylint runs after hard numpy dep drop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
                 python-version: '3.x'
         -   name: "Main Script"
             run: |
-                EXTRA_INSTALL="pymbolic"
+                EXTRA_INSTALL="numpy pymbolic"
                 curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/prepare-and-run-pylint.sh
                 . ./prepare-and-run-pylint.sh "$(basename $GITHUB_REPOSITORY)" test/test_*.py
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ Mypy:
 
 Pylint:
   script:
-  - EXTRA_INSTALL="pymbolic"
+  - EXTRA_INSTALL="numpy pymbolic"
   - py_version=3
   - curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/prepare-and-run-pylint.sh
   - . ./prepare-and-run-pylint.sh "$CI_PROJECT_NAME" test/test_*.py


### PR DESCRIPTION
Fixes CI failures: https://github.com/inducer/pytools/runs/6541237497?check_suite_focus=true