### PR TITLE
add strtobool()

### DIFF
--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -2917,18 +2917,24 @@ def sphere_sample_fibonacci(
 def strtobool(val: Optional[str], default: Optional[bool] = None) -> bool:
     """Convert a string representation of truth to True or False.
     True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
-    are 'n', 'no', 'f', 'false', 'off', and '0'.  If *default* is None,
-    raises ValueError if *val* is anything else. If *val* is None and
-    *default* is not None, returns *default*. Based on
-    :func:`distutils.util.strtobool`.
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Uppercase versions are
+    also accepted. If *default* is None, raises ValueError if *val* is anything
+    else. If *val* is None and *default* is not None, returns *default*.
+    Based on :func:`distutils.util.strtobool`.
 
     :param val: Value to convert.
     :param default: Value to return if *val* is None.
 
-    :returns: True or False.
+    :returns: Truth value of *val*.
     """
     if val is None and default is not None:
         return default
+
+    if val is None:
+        raise ValueError(f"invalid truth value '{val}'. "
+                          "Valid values are ('y', 'yes', 't', 'true', 'on', '1') "
+                          "for 'True' and ('n', 'no', 'f', 'false', 'off', '0') "
+                          "for 'False'. Uppercase versions are also accepted.")
 
     val = val.lower()
     if val in ("y", "yes", "t", "true", "on", "1"):
@@ -2939,7 +2945,7 @@ def strtobool(val: Optional[str], default: Optional[bool] = None) -> bool:
         raise ValueError(f"invalid truth value '{val}'. "
                           "Valid values are ('y', 'yes', 't', 'true', 'on', '1') "
                           "for 'True' and ('n', 'no', 'f', 'false', 'off', '0') "
-                          "for 'False'.")
+                          "for 'False'. Uppercase versions are also accepted.")
 
 # }}}
 

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -2933,7 +2933,7 @@ def strtobool(val: str, default: Optional[bool] = None) -> bool:
         return False
     else:
         if default is None:
-            raise ValueError(f"invalid truth value {val}")
+            raise ValueError(f"invalid truth value '{val}'")
         else:
             return default
 

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -2918,24 +2918,28 @@ def strtobool(val: str, default: Optional[bool] = None) -> bool:
     """Convert a string representation of truth to True or False.
     True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
     are 'n', 'no', 'f', 'false', 'off', and '0'.  If *default* is None,
-    raises ValueError if *val* is anything else. Otherwise, returns
-    *default*. Based on :func:`distutils.util.strtobool`.
+    raises ValueError if *val* is anything else. If *val* is None and
+    *default* is not None, returns *default*. Based on
+    :func:`distutils.util.strtobool`.
 
     :param val: Value to convert.
-    :param default: Value to return if *val* can not be converted.
+    :param default: Value to return if *val* is None.
 
     :returns: True or False.
     """
+    if val is None and default is not None:
+        return default
+
     val = val.lower()
     if val in ("y", "yes", "t", "true", "on", "1"):
         return True
     elif val in ("n", "no", "f", "false", "off", "0"):
         return False
     else:
-        if default is None:
-            raise ValueError(f"invalid truth value '{val}'")
-        else:
-            return default
+        raise ValueError(f"invalid truth value '{val}'. "
+                          "Valid values are ('y', 'yes', 't', 'true', 'on', '1') "
+                          "for 'True' and ('n', 'no', 'f', 'false', 'off', '0') "
+                          "for 'False'.")
 
 # }}}
 

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -2914,7 +2914,7 @@ def sphere_sample_fibonacci(
 
 # {{{ strtobool
 
-def strtobool(val: str, default: Optional[bool] = None) -> bool:
+def strtobool(val: Optional[str], default: Optional[bool] = None) -> bool:
     """Convert a string representation of truth to True or False.
     True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
     are 'n', 'no', 'f', 'false', 'off', and '0'.  If *default* is None,

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -179,6 +179,11 @@ Sampling
 .. autofunction:: sphere_sample_equidistant
 .. autofunction:: sphere_sample_fibonacci
 
+String utilities
+----------------
+
+.. autofunction:: strtobool
+
 Type Variables Used
 -------------------
 
@@ -2903,6 +2908,34 @@ def sphere_sample_fibonacci(
         r * np.sin(theta) * np.sin(phi),
         r * np.cos(theta)
         ])
+
+# }}}
+
+
+# {{{ strtobool
+
+def strtobool(val: str, default: Optional[bool] = None) -> bool:
+    """Convert a string representation of truth to True or False.
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  If *default* is None,
+    raises ValueError if *val* is anything else. Otherwise, returns
+    *default*. Based on :func:`distutils.util.strtobool`.
+
+    :param val: Value to convert.
+    :param default: Value to return if *val* can not be converted.
+
+    :returns: True or False.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        if default is None:
+            raise ValueError(f"invalid truth value {val}")
+        else:
+            return default
 
 # }}}
 

--- a/test/test_pytools.py
+++ b/test/test_pytools.py
@@ -703,6 +703,32 @@ def test_ignoredforequalitytag():
     assert hash(eq1) != hash(eq3)
 
 
+def test_strtobool():
+    from pytools import strtobool
+    assert strtobool("true") is True
+    assert strtobool("tRuE") is True
+    assert strtobool("1") is True
+    assert strtobool("t") is True
+    assert strtobool("on") is True
+
+    assert strtobool("false") is False
+    assert strtobool("FaLse") is False
+    assert strtobool("0") is False
+    assert strtobool("f") is False
+    assert strtobool("off") is False
+
+    with pytest.raises(ValueError):
+        strtobool("tru")
+        strtobool("fal")
+        strtobool("xxx")
+        strtobool(".")
+
+    assert strtobool("tru", False) is False
+    assert strtobool("fal", True) is True
+    assert strtobool("xxx", True) is True
+    assert strtobool(".", True) is True
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])

--- a/test/test_pytools.py
+++ b/test/test_pytools.py
@@ -723,10 +723,7 @@ def test_strtobool():
         strtobool("xxx")
         strtobool(".")
 
-    assert strtobool("tru", False) is False
-    assert strtobool("fal", True) is True
-    assert strtobool("xxx", True) is True
-    assert strtobool(".", True) is True
+    assert strtobool(None, False) is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Based on the now-deprecated [distutils.util.strtobool](https://docs.python.org/3/distutils/apiref.html#distutils.util.strtobool).

Intended to make code like https://github.com/inducer/pytato/blob/a0fa84a5ca17a32f57431b8d67d0383f4c94839c/pytato/__init__.py#L32-L40 more robust.