### PR TITLE
Set Ubuntu CI image to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ on:
 jobs:
     flake8:
         name: Flake8
-        runs-on: ubuntu-latest
+        # Newer images have no Python 3.6 support
+        runs-on: ubuntu-20.04
         steps:
         -   uses: actions/checkout@v3
         -
@@ -67,7 +68,8 @@ jobs:
 
     pytest:
         name: Pytest on Py${{ matrix.python-version }}
-        runs-on: ubuntu-latest
+        # Newer images have no Python 3.6 support
+        runs-on: ubuntu-20.04
         strategy:
             matrix:
                 python-version: ["3.6", "3.8", "3.9", "3.x", "pypy3.8"]


### PR DESCRIPTION
Newer images have no Python 3.6 support:
https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

See e.g. https://github.com/inducer/pytools/actions/runs/3492840943/jobs/5847030018 for a failing CI run which tries to use Ubuntu 22.04 with Python 3.6.