### PR TITLE
typedump: type improvements

### DIFF
--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -2073,15 +2073,14 @@ def typedump(val: Any, max_seq: int = 5,
 
         try:
             if len(val) > max_seq:
-                return "{}({},...)".format(
-                        objname(val),
-                        ",".join(typedump(x, max_seq, special_handlers)
-                            for x in val[:max_seq]))
+                t = ",".join(typedump(x, max_seq, special_handlers)
+                            for x in val[:max_seq])
+                return f"{objname(val)}({t},...)"
             else:
-                return "{}({})".format(
-                        objname(val),
-                        ",".join(typedump(x, max_seq, special_handlers)
-                            for x in val))
+                t = ",".join(typedump(x, max_seq, special_handlers)
+                            for x in val)
+                return f"{objname(val)}({t})"
+
         except TypeError:
             return objname(val)
 

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -36,8 +36,8 @@ import sys
 from functools import reduce, wraps
 from sys import intern
 from typing import (
-    Any, Callable, ClassVar, Dict, Generic, Hashable, Iterable, List, Optional, Set,
-    Tuple, TypeVar, Union, Type, Mapping)
+    Any, Callable, ClassVar, Dict, Generic, Hashable, Iterable, List, Mapping,
+    Optional, Set, Tuple, Type, TypeVar, Union)
 
 
 try:

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -2027,7 +2027,7 @@ def typedump(val: Any, max_seq: int = 5,
     :arg max_seq: For iterable objects, the maximum number of elements to
         include in the return string. Lower this value if you get a
         :class:`RecursionError`.
-    :arg special_handlers: A optional mapping of specific types to special
+    :arg special_handlers: An optional mapping of specific types to special
         handlers.
     :arg fully_qualified_name: Return fully qualified names, that is,
         include module names and use ``__qualname__`` instead of ``__name__``.

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -2083,7 +2083,7 @@ def typedump(val: Any, max_seq: int = 5,
                         ",".join(typedump(x, max_seq, special_handlers)
                             for x in val))
         except TypeError:
-            return val.__class__.__name__
+            return objname(val)
 
 
 def invoke_editor(s, filename="edit.txt", descr="the file"):

--- a/test/test_pytools.py
+++ b/test/test_pytools.py
@@ -733,15 +733,19 @@ def test_strtobool():
 def test_typedump():
     from pytools import typedump
     assert typedump("") == "str"
+    assert typedump("abcdefg") == "str"
     assert typedump(5) == "int"
 
     assert typedump((5.0, 4)) == "tuple(float,int)"
     assert typedump([5, 4]) == "list(int,int)"
     assert typedump({5, 4}) == "set(int,int)"
+    assert typedump(frozenset((1, 2, 3))) == "frozenset(int,int,int)"
 
     assert typedump([5, 4, 3, 2, 1]) == "list(int,int,int,int,int)"
     assert typedump([5, 4, 3, 2, 1, 0]) == "list(int,int,int,int,int,...)"
     assert typedump([5, 4, 3, 2, 1, 0], max_seq=6) == "list(int,int,int,int,int,int)"
+
+    assert typedump({5: 42, 7: 43}) == "{'5': int, '7': int}"
 
     class C:
         class D:

--- a/test/test_pytools.py
+++ b/test/test_pytools.py
@@ -726,6 +726,34 @@ def test_strtobool():
     assert strtobool(None, False) is False
 
 
+def test_typedump():
+    from pytools import typedump
+    assert typedump("") == "str"
+    assert typedump(5) == "int"
+
+    assert typedump((5.0, 4)) == "tuple(float,int)"
+    assert typedump([5, 4]) == "list(int,int)"
+    assert typedump({5, 4}) == "set(int,int)"
+
+    assert typedump([5, 4, 3, 2, 1]) == "list(int,int,int,int,int)"
+    assert typedump([5, 4, 3, 2, 1, 0]) == "list(int,int,int,int,int,...)"
+    assert typedump([5, 4, 3, 2, 1, 0], max_seq=6) == "list(int,int,int,int,int,int)"
+
+    class C:
+        class D:
+            pass
+
+    assert typedump(C()) == "test_pytools.test_typedump.<locals>.C"
+    assert typedump(C.D()) == "test_pytools.test_typedump.<locals>.C.D"
+    assert typedump(C.D(), fully_qualified_name=False) == "D"
+
+    from pytools.datatable import DataTable
+    t = DataTable(column_names=[])
+
+    assert typedump(t) == "pytools.datatable.DataTable()"
+    assert typedump(t, special_handlers={type(t): lambda x: "foo"}) == "foo"
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
- show fully qualified name by default
- better handling of nested classes via `__qualname__`
- add test
- add type annotations, better doc

before:

`
{'queue': CommandQueue, 'shape': tuple(int,int), 'dtype': dtype[float64], 'strides': tuple(int,int), 'events': list(Event), 'nbytes': int, 'size': int, 'allocator': SVMPool, 'base_data': PooledSVM, 'offset': int, 'context': Context, '_flags': NoneType, 'tags': frozenset(), 'axes': tuple(Axis,Axis)}
`

after:

`
{'queue': pyopencl._cl.CommandQueue, 'shape': tuple(int,int), 'dtype': dtype[float64], 'strides': tuple(int,int), 'events': list(pyopencl._cl.Event), 'nbytes': int, 'size': int, 'allocator': pyopencl._cl.SVMPool, 'base_data': pyopencl._cl.PooledSVM, 'offset': int, 'context': pyopencl._cl.Context, '_flags': NoneType, 'tags': frozenset(), 'axes': tuple(arraycontext.impl.pyopencl.taggable_cl_array.Axis,arraycontext.impl.pyopencl.taggable_cl_array.Axis)}
`