### PR TITLE
persistent_dict: add support for numpy 1.25

### DIFF
--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -236,12 +236,21 @@ class KeyBuilder:
             tname = tp.__name__
             method = None
             try:
-                method = getattr(self, "update_for_"+tname)
+                method = getattr(self, f"update_for_{tname}")
             except AttributeError:
-                # Handling numpy >= 1.20, for which
-                # type(np.dtype("float32")) -> "dtype[float32]"
+                # Handling numpy >= 1.20 for which
+                #   >>> type(np.dtype("float32"))
+                #   <class 'numpy.dtype[float32]'>
                 if tname.startswith("dtype[") and "numpy" in sys.modules:
                     import numpy as np
+                    if isinstance(key, np.dtype):
+                        method = self.update_for_specific_dtype
+
+                # Handling numpy >= 1.25 for which
+                #   >>> type(np.dtype("float32"))
+                #   <class 'numpy.dtypes.Float32DType'>
+                elif tname.endswith("DType") and "numpy" in sys.modules:
+                    import numpy as np  # noqa: F811
                     if isinstance(key, np.dtype):
                         method = self.update_for_specific_dtype
 


### PR DESCRIPTION
All the dtypes have moved to `numpy.dtypes` and have names like `Float32DType`. This updates the heuristic to also include this case.

See the release notes https://numpy.org/doc/stable/release/1.25.0-notes.html#numpy-now-exposes-dtype-classes-in-np-dtypes