### PR TITLE
remove pytools.log reference from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,6 @@ nonetheless, here's what's on offer:
 * A ton of small tool functions such as `len_iterable`, `argmin`,
   tuple generation, permutation generation, ASCII table pretty printing,
   GvR's monkeypatch_xxx() hack, the elusive `flatten`, and much more.
-* A time-series logging module, `pytools.log`.
 * Batch job submission, `pytools.batchjob`.
 * A lexer, `pytools.lex`.
 


### PR DESCRIPTION
(this has been moved to logpyle, as the comment a bit lower indicates)