### PR TITLE
KeyBuilder: allow hashing of classes that define update_persistent_hash

### DIFF
--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -224,7 +224,7 @@ class KeyBuilder:
 
         digest = getattr(key, "_pytools_persistent_hash_digest", None)
 
-        if digest is None:
+        if digest is None and not isinstance(key, type):
             try:
                 method = key.update_persistent_hash
             except AttributeError:

--- a/pytools/test/test_persistent_dict.py
+++ b/pytools/test/test_persistent_dict.py
@@ -470,6 +470,28 @@ def test_frozenorderedset_hashing():
     assert keyb(FrozenOrderedSet([1, 2, 3])) == keyb(FrozenOrderedSet([3, 2, 1]))
 
 
+def test_class_hashing():
+    keyb = KeyBuilder()
+
+    class WithUpdateMethod:
+        def update_persistent_hash(self, key_hash, key_builder):
+            # Only called for instances of this class, not for the class itself
+            key_builder.rec(key_hash, 42)
+
+    class TagClass(Tag):
+        # Inherits update_persistent_hash from 'Tag'
+        pass
+
+    @tag_dataclass
+    class TagClass2(Tag):
+        # Inherits update_persistent_hash from 'Tag'
+        pass
+
+    assert keyb(WithUpdateMethod) != keyb(WithUpdateMethod())
+    assert keyb(TagClass) != keyb(TagClass())
+    assert keyb(TagClass2) != keyb(TagClass2())
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
The three test classes (not objects) are unhashable without this PR.