### PR TITLE
Tag: remove update_persistent_hash

### DIFF
--- a/pytools/tag.py
+++ b/pytools/tag.py
@@ -143,19 +143,6 @@ class Tag:
     def tag_name(self) -> DottedName:
         return DottedName.from_class(type(self))
 
-    def update_persistent_hash(self, key_hash, key_builder):
-        key_builder.rec(key_hash,
-                (self.__class__.__module__, self.__class__.__qualname__))
-
-        from dataclasses import fields
-
-        # Fields are ordered consistently, so ordered hashing is OK.
-        #
-        # No need to dispatch to superclass: fields() automatically gives us
-        # fields from the entire class hierarchy.
-        for f in fields(self):
-            key_builder.rec(key_hash, getattr(self, f.name))
-
 # }}}
 
 

--- a/pytools/test/test_persistent_dict.py
+++ b/pytools/test/test_persistent_dict.py
@@ -515,6 +515,21 @@ def test_class_hashing():
     assert keyb(TagClass) != keyb(TagClass())
     assert keyb(TagClass2) != keyb(TagClass2())
 
+    assert keyb(TagClass) != keyb(TagClass2)
+    assert keyb(TagClass()) != keyb(TagClass2())
+
+    assert keyb(TagClass()) == \
+        "f5697a96dde0083e31a290b54ee7a5640b2bb8eb6d18e9c7ee89228b015a6131"
+    assert keyb(TagClass2) == \
+        "4bd9487e0dbea99d609233dba7e7105ccb10ab3e4262275c3890d945d1eb7eee"
+
+    @tag_dataclass
+    class TagClass3(Tag):
+        s: str
+
+    assert keyb(TagClass3("foo")) == \
+        "c6521f4157ed530d04e956b7046db85e038c120b047cd1b848340d81f9fd8b4a"
+
 
 def test_dataclass_hashing():
     keyb = KeyBuilder()

--- a/pytools/test/test_persistent_dict.py
+++ b/pytools/test/test_persistent_dict.py
@@ -505,12 +505,10 @@ def test_class_hashing():
             key_builder.rec(key_hash, 42)
 
     class TagClass(Tag):
-        # Inherits update_persistent_hash from 'Tag'
         pass
 
     @tag_dataclass
     class TagClass2(Tag):
-        # Inherits update_persistent_hash from 'Tag'
         pass
 
     assert keyb(WithUpdateMethod) != keyb(WithUpdateMethod())


### PR DESCRIPTION
Needs #196.

Hashing is now handled directly through the dataclass.