### PR TITLE
PersistentDict: honor XDG_CACHE_HOME on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,12 @@ jobs:
                 . ./prepare-and-run-mypy.sh python3 mypy
 
     pytest:
-        name: Pytest on Py${{ matrix.python-version }}
-        runs-on: ubuntu-latest
+        name: Pytest on Py${{ matrix.python-version }} ${{ matrix.os }}
+        runs-on: ${{ matrix.os }}
         strategy:
             matrix:
                 python-version: ["3.8", "3.9", "3.x", "pypy3.8"]
+                os: [ubuntu-latest, macos-latest]
         steps:
         -   uses: actions/checkout@v4
         -

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -556,8 +556,15 @@ class _PersistentDictBase:
             except ImportError:
                 import appdirs
 
+            if sys.platform == "darwin" and os.getenv("XDG_CACHE_HOME") is not None:
+                # appdirs and platformdirs do not handle XDG_CACHE_HOME on macOS
+                # https://github.com/platformdirs/platformdirs/issues/269
+                cache_dir = join(os.getenv("XDG_CACHE_HOME"), "pytools")
+            else:
+                cache_dir = appdirs.user_cache_dir("pytools", "pytools")
+
             container_dir = join(
-                    appdirs.user_cache_dir("pytools", "pytools"),
+                    cache_dir,
                     "pdict-v4-{}-py{}".format(
                         identifier,
                         ".".join(str(i) for i in sys.version_info)))

--- a/pytools/test/test_persistent_dict.py
+++ b/pytools/test/test_persistent_dict.py
@@ -582,6 +582,28 @@ def test_attrs_hashing():
     assert keyb(MyAttrs2("hi", 1)) != keyb(MyAttrs("hi", 1))
 
 
+def test_xdg_cache_home():
+    import os
+    xdg_dir = "tmpdir_pytools_xdg_test"
+
+    assert not os.path.exists(xdg_dir)
+
+    try:
+        old_xdg_cache_home = os.getenv("XDG_CACHE_HOME")
+        os.environ["XDG_CACHE_HOME"] = xdg_dir
+
+        PersistentDict("pytools-test")
+
+        assert os.path.exists(xdg_dir)
+    finally:
+        if old_xdg_cache_home is not None:
+            os.environ["XDG_CACHE_HOME"] = old_xdg_cache_home
+        else:
+            del os.environ["XDG_CACHE_HOME"]
+
+        shutil.rmtree(xdg_dir)
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
`appdirs` and `platformdirs` do not handle `XDG_CACHE_HOME` on macOS: https://github.com/platformdirs/platformdirs/issues/269 https://github.com/platformdirs/platformdirs/issues/4, and there seems to be no other way to select a custom cache path via platformdirs on macOS at all.

_This adds MacOS pytest to CI, the 'Required for merge' tests need to be adjusted in the GitHub repo config._