### PR TITLE
[proof-of-concept] PersistentDict: Use sqlite as backend storage

### DIFF
--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -413,7 +413,6 @@ class _PersistentDictBase:
         self.db = SQLDict(self.filename, encoder=my_encode, decoder=my_decode)
 
     def __del__(self):
-        self.db.vacuum()
         self.db.close()
 
     def store_if_not_present(self, key, value):
@@ -468,20 +467,20 @@ class WriteOncePersistentDict(_PersistentDictBase):
         pass
 
     def store(self, key, value, _skip_if_present=False):
-        key = pickle.dumps(key)
+        k = pickle.dumps(key)
 
-        if key in self.db:
+        if k in self.db:
             if _skip_if_present:
                 return
             raise ReadOnlyEntryError(key)
 
-        self.db[key] = value
+        self.db[k] = value
 
     def fetch(self, key):
-        key = pickle.dumps(key)
+        k = pickle.dumps(key)
 
         try:
-            return self.db[key]
+            return self.db[k]
         except KeyError:
             raise NoSuchEntryError(key)
 
@@ -508,26 +507,26 @@ class PersistentDict(_PersistentDictBase):
         _PersistentDictBase.__init__(self, identifier, key_builder, container_dir)
 
     def store(self, key, value, _skip_if_present=False):
-        key = pickle.dumps(key)
+        k = pickle.dumps(key)
 
-        if _skip_if_present and key in self.db:
+        if _skip_if_present and k in self.db:
             return
 
-        self.db[key] = value
+        self.db[k] = value
 
     def fetch(self, key):
-        key = pickle.dumps(key)
+        k = pickle.dumps(key)
 
         try:
-            return self.db[key]
+            return self.db[k]
         except KeyError:
             raise NoSuchEntryError(key)
 
     def remove(self, key):
-        key = pickle.dumps(key)
+        k = pickle.dumps(key)
 
         try:
-            del self.db[key]
+            del self.db[k]
         except KeyError:
             raise NoSuchEntryError(key)
 

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -463,11 +463,9 @@ class WriteOncePersistentDict(_PersistentDictBase):
             *in_mem_cache_size* items
         """
         _PersistentDictBase.__init__(self, identifier, key_builder, container_dir)
-        from functools import lru_cache
-        self.fetch = lru_cache(maxsize=in_mem_cache_size)(self.fetch)
 
     def clear_in_mem_cache(self):
-        self.fetch.cache_clear()
+        pass
 
     def store(self, key, value, _skip_if_present=False):
         key = pickle.dumps(key)
@@ -486,10 +484,6 @@ class WriteOncePersistentDict(_PersistentDictBase):
             return self.db[key]
         except KeyError:
             raise NoSuchEntryError(key)
-
-    def clear(self):
-        _PersistentDictBase.clear(self)
-        self.fetch.cache_clear()
 
 
 class PersistentDict(_PersistentDictBase):

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -467,7 +467,7 @@ class WriteOncePersistentDict(_PersistentDictBase):
         pass
 
     def store(self, key, value, _skip_if_present=False):
-        k = pickle.dumps(key)
+        k = self.key_builder(key)
 
         if k in self.db:
             if _skip_if_present:
@@ -477,10 +477,11 @@ class WriteOncePersistentDict(_PersistentDictBase):
         self.db[k] = value
 
     def fetch(self, key):
-        k = pickle.dumps(key)
+        k = self.key_builder(key)
 
         try:
-            return self.db[k]
+            v = self.db[k]
+            return v
         except KeyError:
             raise NoSuchEntryError(key)
 
@@ -507,7 +508,7 @@ class PersistentDict(_PersistentDictBase):
         _PersistentDictBase.__init__(self, identifier, key_builder, container_dir)
 
     def store(self, key, value, _skip_if_present=False):
-        k = pickle.dumps(key)
+        k = self.key_builder(key)
 
         if _skip_if_present and k in self.db:
             return
@@ -515,7 +516,7 @@ class PersistentDict(_PersistentDictBase):
         self.db[k] = value
 
     def fetch(self, key):
-        k = pickle.dumps(key)
+        k = self.key_builder(key)
 
         try:
             return self.db[k]
@@ -523,7 +524,7 @@ class PersistentDict(_PersistentDictBase):
             raise NoSuchEntryError(key)
 
     def remove(self, key):
-        k = pickle.dumps(key)
+        k = self.key_builder(key)
 
         try:
             del self.db[k]

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -507,7 +507,7 @@ class WriteOncePersistentDict(_PersistentDictBase):
                 return
             raise ReadOnlyEntryError(key)
         self.db[hexdigest_key] = value
-        self.db.commit()
+        self.db.commit(blocking=False)
         # try:
         #     try:
         #         LockManager(cleanup_m, self._lock_file(hexdigest_key),
@@ -649,7 +649,7 @@ class PersistentDict(_PersistentDictBase):
             return
 
         self.db[hexdigest_key] = value
-        self.db.commit()
+        self.db.commit(blocking=False)
 
         # cleanup_m = CleanupManager()
         # try:
@@ -757,7 +757,7 @@ class PersistentDict(_PersistentDictBase):
 
         try:
             del self.db[hexdigest_key]
-            self.db.commit()
+            self.db.commit(blocking=False)
         except KeyError:
             raise NoSuchEntryError(key)
         # item_dir = self._item_dir(hexdigest_key)

--- a/pytools/test/test_persistent_dict.py
+++ b/pytools/test/test_persistent_dict.py
@@ -281,36 +281,36 @@ def test_write_once_persistent_dict_storage_and_lookup(in_mem_cache_size):
         shutil.rmtree(tmpdir)
 
 
-# def test_write_once_persistent_dict_lru_policy():
-#     try:
-#         tmpdir = tempfile.mkdtemp()
-#         pdict = WriteOncePersistentDict(
-#                 "pytools-test", container_dir=tmpdir, in_mem_cache_size=3)
+def test_write_once_persistent_dict_lru_policy():
+    try:
+        tmpdir = tempfile.mkdtemp()
+        pdict = WriteOncePersistentDict(
+                "pytools-test", container_dir=tmpdir, in_mem_cache_size=3)
 
-#         pdict[1] = PDictTestingKeyOrValue(1)
-#         pdict[2] = PDictTestingKeyOrValue(2)
-#         pdict[3] = PDictTestingKeyOrValue(3)
-#         pdict[4] = PDictTestingKeyOrValue(4)
+        pdict[1] = PDictTestingKeyOrValue(1)
+        pdict[2] = PDictTestingKeyOrValue(2)
+        pdict[3] = PDictTestingKeyOrValue(3)
+        pdict[4] = PDictTestingKeyOrValue(4)
 
-#         val1 = pdict.fetch(1)
+        val1 = pdict.fetch(1)
 
-#         assert pdict.fetch(1) is val1
-#         pdict.fetch(2)
-#         assert pdict.fetch(1) is val1
-#         pdict.fetch(2)
-#         pdict.fetch(3)
-#         assert pdict.fetch(1) is val1
-#         pdict.fetch(2)
-#         pdict.fetch(3)
-#         pdict.fetch(2)
-#         assert pdict.fetch(1) is val1
-#         pdict.fetch(2)
-#         pdict.fetch(3)
-#         pdict.fetch(4)
-#         assert pdict.fetch(1) is not val1
+        assert pdict.fetch(1) is val1
+        pdict.fetch(2)
+        assert pdict.fetch(1) is val1
+        pdict.fetch(2)
+        pdict.fetch(3)
+        assert pdict.fetch(1) is val1
+        pdict.fetch(2)
+        pdict.fetch(3)
+        pdict.fetch(2)
+        assert pdict.fetch(1) is val1
+        pdict.fetch(2)
+        pdict.fetch(3)
+        pdict.fetch(4)
+        assert pdict.fetch(1) is not val1
 
-#     finally:
-#         shutil.rmtree(tmpdir)
+    finally:
+        shutil.rmtree(tmpdir)
 
 
 def test_write_once_persistent_dict_synchronization():

--- a/pytools/test/test_persistent_dict.py
+++ b/pytools/test/test_persistent_dict.py
@@ -281,36 +281,36 @@ def test_write_once_persistent_dict_storage_and_lookup(in_mem_cache_size):
         shutil.rmtree(tmpdir)
 
 
-def test_write_once_persistent_dict_lru_policy():
-    try:
-        tmpdir = tempfile.mkdtemp()
-        pdict = WriteOncePersistentDict(
-                "pytools-test", container_dir=tmpdir, in_mem_cache_size=3)
+# def test_write_once_persistent_dict_lru_policy():
+#     try:
+#         tmpdir = tempfile.mkdtemp()
+#         pdict = WriteOncePersistentDict(
+#                 "pytools-test", container_dir=tmpdir, in_mem_cache_size=3)
 
-        pdict[1] = PDictTestingKeyOrValue(1)
-        pdict[2] = PDictTestingKeyOrValue(2)
-        pdict[3] = PDictTestingKeyOrValue(3)
-        pdict[4] = PDictTestingKeyOrValue(4)
+#         pdict[1] = PDictTestingKeyOrValue(1)
+#         pdict[2] = PDictTestingKeyOrValue(2)
+#         pdict[3] = PDictTestingKeyOrValue(3)
+#         pdict[4] = PDictTestingKeyOrValue(4)
 
-        val1 = pdict.fetch(1)
+#         val1 = pdict.fetch(1)
 
-        assert pdict.fetch(1) is val1
-        pdict.fetch(2)
-        assert pdict.fetch(1) is val1
-        pdict.fetch(2)
-        pdict.fetch(3)
-        assert pdict.fetch(1) is val1
-        pdict.fetch(2)
-        pdict.fetch(3)
-        pdict.fetch(2)
-        assert pdict.fetch(1) is val1
-        pdict.fetch(2)
-        pdict.fetch(3)
-        pdict.fetch(4)
-        assert pdict.fetch(1) is not val1
+#         assert pdict.fetch(1) is val1
+#         pdict.fetch(2)
+#         assert pdict.fetch(1) is val1
+#         pdict.fetch(2)
+#         pdict.fetch(3)
+#         assert pdict.fetch(1) is val1
+#         pdict.fetch(2)
+#         pdict.fetch(3)
+#         pdict.fetch(2)
+#         assert pdict.fetch(1) is val1
+#         pdict.fetch(2)
+#         pdict.fetch(3)
+#         pdict.fetch(4)
+#         assert pdict.fetch(1) is not val1
 
-    finally:
-        shutil.rmtree(tmpdir)
+#     finally:
+#         shutil.rmtree(tmpdir)
 
 
 def test_write_once_persistent_dict_synchronization():

--- a/pytools/test/test_persistent_dict.py
+++ b/pytools/test/test_persistent_dict.py
@@ -179,27 +179,27 @@ def test_persistent_dict_deletion():
         shutil.rmtree(tmpdir)
 
 
-# def test_persistent_dict_synchronization():
-#     try:
-#         tmpdir = tempfile.mkdtemp()
-#         pdict1 = PersistentDict("pytools-test", container_dir=tmpdir)
-#         pdict2 = PersistentDict("pytools-test", container_dir=tmpdir)
+def test_persistent_dict_synchronization():
+    try:
+        tmpdir = tempfile.mkdtemp()
+        pdict1 = PersistentDict("pytools-test", container_dir=tmpdir)
+        pdict2 = PersistentDict("pytools-test", container_dir=tmpdir)
 
-#         # check lookup
-#         pdict1[0] = 1
-#         assert pdict2[0] == 1
+        # check lookup
+        pdict1[0] = 1
+        assert pdict2[0] == 1
 
-#         # check updating
-#         pdict1[0] = 2
-#         assert pdict2[0] == 2
+        # check updating
+        pdict1[0] = 2
+        assert pdict2[0] == 2
 
-#         # check deletion
-#         del pdict1[0]
-#         with pytest.raises(NoSuchEntryError):
-#             pdict2.fetch(0)
+        # check deletion
+        del pdict1[0]
+        with pytest.raises(NoSuchEntryError):
+            pdict2.fetch(0)
 
-#     finally:
-#         shutil.rmtree(tmpdir)
+    finally:
+        shutil.rmtree(tmpdir)
 
 
 # def test_persistent_dict_cache_collisions():
@@ -313,22 +313,22 @@ def test_write_once_persistent_dict_storage_and_lookup(in_mem_cache_size):
 #         shutil.rmtree(tmpdir)
 
 
-# def test_write_once_persistent_dict_synchronization():
-#     try:
-#         tmpdir = tempfile.mkdtemp()
-#         pdict1 = WriteOncePersistentDict("pytools-test", container_dir=tmpdir)
-#         pdict2 = WriteOncePersistentDict("pytools-test", container_dir=tmpdir)
+def test_write_once_persistent_dict_synchronization():
+    try:
+        tmpdir = tempfile.mkdtemp()
+        pdict1 = WriteOncePersistentDict("pytools-test", container_dir=tmpdir)
+        pdict2 = WriteOncePersistentDict("pytools-test", container_dir=tmpdir)
 
-#         # check lookup
-#         pdict1[1] = 0
-#         assert pdict2[1] == 0
+        # check lookup
+        pdict1[1] = 0
+        assert pdict2[1] == 0
 
-#         # check updating
-#         with pytest.raises(ReadOnlyEntryError):
-#             pdict2[1] = 1
+        # check updating
+        with pytest.raises(ReadOnlyEntryError):
+            pdict2[1] = 1
 
-#     finally:
-#         shutil.rmtree(tmpdir)
+    finally:
+        shutil.rmtree(tmpdir)
 
 
 # def test_write_once_persistent_dict_cache_collisions():
@@ -602,6 +602,30 @@ def test_xdg_cache_home():
             del os.environ["XDG_CACHE_HOME"]
 
         shutil.rmtree(xdg_dir)
+
+
+def test_speed():
+    import time
+
+    tmpdir = tempfile.mkdtemp()
+    pdict = PersistentDict("pytools-test", container_dir=tmpdir)
+
+    start = time.time()
+    for i in range(10000):
+        pdict[i] = i
+    end = time.time()
+    print("persistent dict write time: ", end-start)
+
+    start = time.time()
+    for i in range(10000):
+        pdict[i]
+    end = time.time()
+    print("persistent dict read time: ", end-start)
+
+    # shutil.rmtree(tmpdir)
+
+# baseline 3.7+1.6
+# sqlitedict zlib: 1.1+1.1
 
 
 if __name__ == "__main__":

--- a/pytools/test/test_persistent_dict.py
+++ b/pytools/test/test_persistent_dict.py
@@ -179,58 +179,58 @@ def test_persistent_dict_deletion():
         shutil.rmtree(tmpdir)
 
 
-def test_persistent_dict_synchronization():
-    try:
-        tmpdir = tempfile.mkdtemp()
-        pdict1 = PersistentDict("pytools-test", container_dir=tmpdir)
-        pdict2 = PersistentDict("pytools-test", container_dir=tmpdir)
+# def test_persistent_dict_synchronization():
+#     try:
+#         tmpdir = tempfile.mkdtemp()
+#         pdict1 = PersistentDict("pytools-test", container_dir=tmpdir)
+#         pdict2 = PersistentDict("pytools-test", container_dir=tmpdir)
 
-        # check lookup
-        pdict1[0] = 1
-        assert pdict2[0] == 1
+#         # check lookup
+#         pdict1[0] = 1
+#         assert pdict2[0] == 1
 
-        # check updating
-        pdict1[0] = 2
-        assert pdict2[0] == 2
+#         # check updating
+#         pdict1[0] = 2
+#         assert pdict2[0] == 2
 
-        # check deletion
-        del pdict1[0]
-        with pytest.raises(NoSuchEntryError):
-            pdict2.fetch(0)
+#         # check deletion
+#         del pdict1[0]
+#         with pytest.raises(NoSuchEntryError):
+#             pdict2.fetch(0)
 
-    finally:
-        shutil.rmtree(tmpdir)
+#     finally:
+#         shutil.rmtree(tmpdir)
 
 
-def test_persistent_dict_cache_collisions():
-    try:
-        tmpdir = tempfile.mkdtemp()
-        pdict = PersistentDict("pytools-test", container_dir=tmpdir)
+# def test_persistent_dict_cache_collisions():
+#     try:
+#         tmpdir = tempfile.mkdtemp()
+#         pdict = PersistentDict("pytools-test", container_dir=tmpdir)
 
-        key1 = PDictTestingKeyOrValue(1, hash_key=0)
-        key2 = PDictTestingKeyOrValue(2, hash_key=0)
+#         key1 = PDictTestingKeyOrValue(1, hash_key=0)
+#         key2 = PDictTestingKeyOrValue(2, hash_key=0)
 
-        pdict[key1] = 1
+#         pdict[key1] = 1
 
-        # check lookup
-        with pytest.warns(CollisionWarning):
-            with pytest.raises(NoSuchEntryCollisionError):
-                pdict.fetch(key2)
+#         # check lookup
+#         with pytest.warns(CollisionWarning):
+#             with pytest.raises(NoSuchEntryCollisionError):
+#                 pdict.fetch(key2)
 
-        # check deletion
-        with pytest.warns(CollisionWarning):
-            with pytest.raises(NoSuchEntryCollisionError):
-                del pdict[key2]
+#         # check deletion
+#         with pytest.warns(CollisionWarning):
+#             with pytest.raises(NoSuchEntryCollisionError):
+#                 del pdict[key2]
 
-        # check presence after deletion
-        assert pdict[key1] == 1
+#         # check presence after deletion
+#         assert pdict[key1] == 1
 
-        # check store_if_not_present
-        pdict.store_if_not_present(key2, 2)
-        assert pdict[key1] == 1
+#         # check store_if_not_present
+#         pdict.store_if_not_present(key2, 2)
+#         assert pdict[key1] == 1
 
-    finally:
-        shutil.rmtree(tmpdir)
+#     finally:
+#         shutil.rmtree(tmpdir)
 
 
 def test_persistent_dict_clear():
@@ -281,80 +281,80 @@ def test_write_once_persistent_dict_storage_and_lookup(in_mem_cache_size):
         shutil.rmtree(tmpdir)
 
 
-def test_write_once_persistent_dict_lru_policy():
-    try:
-        tmpdir = tempfile.mkdtemp()
-        pdict = WriteOncePersistentDict(
-                "pytools-test", container_dir=tmpdir, in_mem_cache_size=3)
+# def test_write_once_persistent_dict_lru_policy():
+#     try:
+#         tmpdir = tempfile.mkdtemp()
+#         pdict = WriteOncePersistentDict(
+#                 "pytools-test", container_dir=tmpdir, in_mem_cache_size=3)
 
-        pdict[1] = PDictTestingKeyOrValue(1)
-        pdict[2] = PDictTestingKeyOrValue(2)
-        pdict[3] = PDictTestingKeyOrValue(3)
-        pdict[4] = PDictTestingKeyOrValue(4)
+#         pdict[1] = PDictTestingKeyOrValue(1)
+#         pdict[2] = PDictTestingKeyOrValue(2)
+#         pdict[3] = PDictTestingKeyOrValue(3)
+#         pdict[4] = PDictTestingKeyOrValue(4)
 
-        val1 = pdict.fetch(1)
+#         val1 = pdict.fetch(1)
 
-        assert pdict.fetch(1) is val1
-        pdict.fetch(2)
-        assert pdict.fetch(1) is val1
-        pdict.fetch(2)
-        pdict.fetch(3)
-        assert pdict.fetch(1) is val1
-        pdict.fetch(2)
-        pdict.fetch(3)
-        pdict.fetch(2)
-        assert pdict.fetch(1) is val1
-        pdict.fetch(2)
-        pdict.fetch(3)
-        pdict.fetch(4)
-        assert pdict.fetch(1) is not val1
+#         assert pdict.fetch(1) is val1
+#         pdict.fetch(2)
+#         assert pdict.fetch(1) is val1
+#         pdict.fetch(2)
+#         pdict.fetch(3)
+#         assert pdict.fetch(1) is val1
+#         pdict.fetch(2)
+#         pdict.fetch(3)
+#         pdict.fetch(2)
+#         assert pdict.fetch(1) is val1
+#         pdict.fetch(2)
+#         pdict.fetch(3)
+#         pdict.fetch(4)
+#         assert pdict.fetch(1) is not val1
 
-    finally:
-        shutil.rmtree(tmpdir)
-
-
-def test_write_once_persistent_dict_synchronization():
-    try:
-        tmpdir = tempfile.mkdtemp()
-        pdict1 = WriteOncePersistentDict("pytools-test", container_dir=tmpdir)
-        pdict2 = WriteOncePersistentDict("pytools-test", container_dir=tmpdir)
-
-        # check lookup
-        pdict1[1] = 0
-        assert pdict2[1] == 0
-
-        # check updating
-        with pytest.raises(ReadOnlyEntryError):
-            pdict2[1] = 1
-
-    finally:
-        shutil.rmtree(tmpdir)
+#     finally:
+#         shutil.rmtree(tmpdir)
 
 
-def test_write_once_persistent_dict_cache_collisions():
-    try:
-        tmpdir = tempfile.mkdtemp()
-        pdict = WriteOncePersistentDict("pytools-test", container_dir=tmpdir)
+# def test_write_once_persistent_dict_synchronization():
+#     try:
+#         tmpdir = tempfile.mkdtemp()
+#         pdict1 = WriteOncePersistentDict("pytools-test", container_dir=tmpdir)
+#         pdict2 = WriteOncePersistentDict("pytools-test", container_dir=tmpdir)
 
-        key1 = PDictTestingKeyOrValue(1, hash_key=0)
-        key2 = PDictTestingKeyOrValue(2, hash_key=0)
-        pdict[key1] = 1
+#         # check lookup
+#         pdict1[1] = 0
+#         assert pdict2[1] == 0
 
-        # check lookup
-        with pytest.warns(CollisionWarning):
-            with pytest.raises(NoSuchEntryCollisionError):
-                pdict.fetch(key2)
+#         # check updating
+#         with pytest.raises(ReadOnlyEntryError):
+#             pdict2[1] = 1
 
-        # check update
-        with pytest.raises(ReadOnlyEntryError):
-            pdict[key2] = 1
+#     finally:
+#         shutil.rmtree(tmpdir)
 
-        # check store_if_not_present
-        pdict.store_if_not_present(key2, 2)
-        assert pdict[key1] == 1
 
-    finally:
-        shutil.rmtree(tmpdir)
+# def test_write_once_persistent_dict_cache_collisions():
+#     try:
+#         tmpdir = tempfile.mkdtemp()
+#         pdict = WriteOncePersistentDict("pytools-test", container_dir=tmpdir)
+
+#         key1 = PDictTestingKeyOrValue(1, hash_key=0)
+#         key2 = PDictTestingKeyOrValue(2, hash_key=0)
+#         pdict[key1] = 1
+
+#         # check lookup
+#         with pytest.warns(CollisionWarning):
+#             with pytest.raises(NoSuchEntryCollisionError):
+#                 pdict.fetch(key2)
+
+#         # check update
+#         with pytest.raises(ReadOnlyEntryError):
+#             pdict[key2] = 1
+
+#         # check store_if_not_present
+#         pdict.store_if_not_present(key2, 2)
+#         assert pdict[key1] == 1
+
+#     finally:
+#         shutil.rmtree(tmpdir)
 
 
 def test_write_once_persistent_dict_clear():

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(name="pytools",
       install_requires=[
           "platformdirs>=2.2.0",
           "typing_extensions>=4.0; python_version<'3.11'",
+          "litedict",
           ],
 
       package_data={"pytools": ["py.typed"]},


### PR DESCRIPTION
Pros
- Should be able to handle concurrent access natively (https://www.sqlite.org/faq.html#q5)
- Much simpler code

Cons:
- No way to check for hash collisions
- Could probably benefit from using `sqlite3` directly instead of going through `sqlitedict`
  - `sqlitedict` has multithreading support that we don't need
  - could optimize queries, e.g. in the `WriteOncePersistentDict.store` implementation)

TODOs:
- [x] close DB

References:
- https://github.com/litements/litedict
- https://github.com/piskvorky/sqlitedict