### PR TITLE
remove get_read_from_map_from_permutation, get_write_to_map_from_permutation

### DIFF
--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -1525,68 +1525,6 @@ def enumerate_basic_directions(dimensions):
 # }}}
 
 
-# {{{ index mangling
-
-def get_read_from_map_from_permutation(original, permuted):
-    """With a permutation given by *original* and *permuted*,
-    generate a list *rfm* of indices such that
-    ``permuted[i] == original[rfm[i]]``.
-
-    Requires that the permutation can be inferred from
-    *original* and *permuted*.
-
-    .. doctest ::
-
-        >>> for p1 in generate_permutations(list(range(5))):
-        ...     for p2 in generate_permutations(list(range(5))):
-        ...         rfm = get_read_from_map_from_permutation(p1, p2)
-        ...         p2a = [p1[rfm[i]] for i in range(len(p1))]
-        ...         assert p2 == p2a
-    """
-    from warnings import warn
-    warn("get_read_from_map_from_permutation is deprecated and will be "
-            "removed in 2019", DeprecationWarning, stacklevel=2)
-
-    assert len(original) == len(permuted)
-    where_in_original = {
-            original[i]: i for i in range(len(original))}
-    assert len(where_in_original) == len(original)
-    return tuple(where_in_original[pi] for pi in permuted)
-
-
-def get_write_to_map_from_permutation(original, permuted):
-    """With a permutation given by *original* and *permuted*,
-    generate a list *wtm* of indices such that
-    ``permuted[wtm[i]] == original[i]``.
-
-    Requires that the permutation can be inferred from
-    *original* and *permuted*.
-
-    .. doctest ::
-
-        >>> for p1 in generate_permutations(list(range(5))):
-        ...     for p2 in generate_permutations(list(range(5))):
-        ...         wtm = get_write_to_map_from_permutation(p1, p2)
-        ...         p2a = [0] * len(p2)
-        ...         for i, oi in enumerate(p1):
-        ...             p2a[wtm[i]] = oi
-        ...         assert p2 == p2a
-    """
-    from warnings import warn
-    warn("get_write_to_map_from_permutation is deprecated and will be "
-            "removed in 2019", DeprecationWarning, stacklevel=2)
-
-    assert len(original) == len(permuted)
-
-    where_in_permuted = {
-            permuted[i]: i for i in range(len(permuted))}
-
-    assert len(where_in_permuted) == len(permuted)
-    return tuple(where_in_permuted[oi] for oi in original)
-
-# }}}
-
-
 # {{{ graph algorithms
 
 from pytools.graph import a_star as a_star_moved


### PR DESCRIPTION
Removes ~29,000 warnings from the doctest.