### PR TITLE
mypy: remove --follow-imports=skip checks

### DIFF
--- a/pytools/test/test_pytools.py
+++ b/pytools/test/test_pytools.py
@@ -172,7 +172,7 @@ def test_memoize_keyfunc():
     assert count[0] == 2
 
 
-def test_memoize_frozen():
+def test_memoize_frozen() -> None:
     from dataclasses import dataclass
 
     from pytools import memoize_method
@@ -187,9 +187,11 @@ def test_memoize_frozen():
         def double_value(self):
             return 2 * self.value
 
-    c = FrozenDataclass(10)
-    assert c.double_value() == 20
-    c.double_value.clear_cache(c)       # pylint: disable=no-member
+    c0 = FrozenDataclass(10)
+    assert c0.double_value() == 20
+
+    # pylint: disable=no-member
+    c0.double_value.clear_cache(c0)  # type: ignore[attr-defined]
 
     # }}}
 
@@ -208,9 +210,11 @@ def test_memoize_frozen():
         def double_value(self):
             return 2 * self.value
 
-    c = FrozenClass(10)
-    assert c.double_value() == 20
-    c.double_value.clear_cache(c)       # pylint: disable=no-member
+    c1 = FrozenClass(10)
+    assert c1.double_value() == 20
+
+    # pylint: disable=no-member
+    c1.double_value.clear_cache(c1)  # type: ignore[attr-defined]
 
     # }}}
 

--- a/run-mypy.sh
+++ b/run-mypy.sh
@@ -1,7 +1,3 @@
 #! /bin/bash
 
-set -ex
-
-mypy --show-error-codes pytools
-
-mypy --strict --follow-imports=skip pytools/datatable.py pytools/persistent_dict.py
+python -m mypy --show-error-codes pytools


### PR DESCRIPTION
This "fixes" the mypy failure on the CI:
https://github.com/inducer/pytools/actions/runs/9630439571/job/26561001591

As far as I can tell, that nice crash was caused by 
```
mypy --strict --follow-imports=skip pytools/persistent_dict.py
```
and seems to be related to https://github.com/python/mypy/issues/17396. I couldn't find any nicer workaround for it though..

cc @matthiasdiener 