### PR TITLE
Fix some typing issues

### DIFF
--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -2768,7 +2768,9 @@ def resolve_name(name):
 
 # {{{ unordered_hash
 
-def unordered_hash(hash_instance, iterable, hash_constructor=None):
+def unordered_hash(hash_instance: Any,
+                   iterable: Iterable[Any],
+                   hash_constructor: Optional[Callable[[], Any]] = None) -> Any:
     """Using a hash algorithm given by the parameter-less constructor
     *hash_constructor*, return a hash object whose internal state
     depends on the entries of *iterable*, but not their order. If *hash*
@@ -2793,6 +2795,8 @@ def unordered_hash(hash_instance, iterable, hash_constructor=None):
         import hashlib
         from functools import partial
         hash_constructor = partial(hashlib.new, hash_instance.name)
+
+    assert hash_constructor is not None
 
     h_int = 0
     for i in iterable:

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -943,10 +943,7 @@ class memoize_in(Generic[P, R]):  # noqa
                 self.cache_dict[args] = result
                 return result
 
-        # NOTE: mypy gets confused because it types `wraps` as
-        #   Callable[[VarArg(Any)], Any]
-        # which, for some reason, is not compatible with `F`
-        return new_inner                # type: ignore[return-value]
+        return new_inner
 
 
 class keyed_memoize_in(Generic[P, R]):  # noqa

--- a/pytools/graph.py
+++ b/pytools/graph.py
@@ -465,7 +465,7 @@ def as_graphviz_dot(graph: GraphT[NodeT],
          for (node, targets) in graph.items()
          for t in targets])
 
-    return f"digraph mygraph {{\n{ content }\n}}\n"
+    return f"digraph mygraph {{\n{content}\n}}\n"
 
 # }}}
 

--- a/pytools/mpiwrap.py
+++ b/pytools/mpiwrap.py
@@ -13,7 +13,8 @@ import pytools.prefork  # pylint:disable=wrong-import-position
 pytools.prefork.enable_prefork()
 
 
-if Is_initialized():  # noqa pylint:disable=undefined-variable
+# pylint: disable-next=undefined-variable
+if Is_initialized():    # type: ignore[name-defined,unused-ignore] # noqa
     raise RuntimeError("MPI already initialized before MPI wrapper import")
 
 

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -39,7 +39,8 @@ import sys
 from dataclasses import fields as dc_fields, is_dataclass
 from enum import Enum
 from typing import (
-    TYPE_CHECKING, Any, Generator, Mapping, Optional, Protocol, Tuple, TypeVar)
+    TYPE_CHECKING, Any, Callable, FrozenSet, Iterator, Mapping, Optional, Protocol,
+    Tuple, TypeVar, cast)
 
 
 if TYPE_CHECKING:
@@ -149,7 +150,7 @@ class KeyBuilder:
 
     # this exists so that we can (conceivably) switch algorithms at some point
     # down the road
-    new_hash = hashlib.sha256
+    new_hash: Callable[..., Hash] = hashlib.sha256
 
     def rec(self, key_hash: Hash, key: Any) -> Hash:
         """
@@ -281,11 +282,11 @@ class KeyBuilder:
     def update_for_bytes(key_hash: Hash, key: bytes) -> None:
         key_hash.update(key)
 
-    def update_for_tuple(self, key_hash: Hash, key: tuple) -> None:
+    def update_for_tuple(self, key_hash: Hash, key: Tuple[Any, ...]) -> None:
         for obj_i in key:
             self.rec(key_hash, obj_i)
 
-    def update_for_frozenset(self, key_hash: Hash, key: frozenset) -> None:
+    def update_for_frozenset(self, key_hash: Hash, key: FrozenSet[Any]) -> None:
         from pytools import unordered_hash
 
         unordered_hash(
@@ -335,7 +336,7 @@ class KeyBuilder:
             self.rec(key_hash, fld.name)
             self.rec(key_hash, getattr(key, fld.name, None))
 
-    def update_for_frozendict(self, key_hash: Hash, key: Mapping) -> None:
+    def update_for_frozendict(self, key_hash: Hash, key: Mapping[Any, Any]) -> None:
         from pytools import unordered_hash
 
         unordered_hash(
@@ -423,12 +424,14 @@ def __getattr__(name: str) -> Any:
     raise AttributeError(name)
 
 
+T = TypeVar("T")
 K = TypeVar("K")
 V = TypeVar("V")
 
 
 class _PersistentDictBase(Mapping[K, V]):
-    def __init__(self, identifier: str,
+    def __init__(self,
+                 identifier: str,
                  key_builder: Optional[KeyBuilder] = None,
                  container_dir: Optional[str] = None,
                  enable_wal: bool = False,
@@ -523,9 +526,17 @@ class _PersistentDictBase(Mapping[K, V]):
             raise NoSuchEntryCollisionError(key)
 
     def _exec_sql(self, *args: Any) -> sqlite3.Cursor:
-        return self._exec_sql_fn(lambda: self.conn.execute(*args))
+        def execute() -> sqlite3.Cursor:
+            assert self.conn is not None
+            return self.conn.execute(*args)
 
-    def _exec_sql_fn(self, fn: Any) -> Any:
+        cursor = self._exec_sql_fn(execute)
+        if not isinstance(cursor, sqlite3.Cursor):
+            raise RuntimeError("Failed to execute SQL statement")
+
+        return cursor
+
+    def _exec_sql_fn(self, fn: Callable[[], T]) -> Optional[T]:
         n = 0
 
         while True:
@@ -570,31 +581,36 @@ class _PersistentDictBase(Mapping[K, V]):
 
     def __len__(self) -> int:
         """Return the number of entries in the dictionary."""
-        return next(self._exec_sql("SELECT COUNT(*) FROM dict"))[0]
+        result, = next(self._exec_sql("SELECT COUNT(*) FROM dict"))
+        assert isinstance(result, int)
+        return result
 
-    def __iter__(self) -> Generator[K, None, None]:
+    def __iter__(self) -> Iterator[K]:
         """Return an iterator over the keys in the dictionary."""
         return self.keys()
 
-    def keys(self) -> Generator[K, None, None]:
+    def keys(self) -> Iterator[K]:  # type: ignore[override]
         """Return an iterator over the keys in the dictionary."""
         for row in self._exec_sql("SELECT key_value FROM dict ORDER BY rowid"):
             yield pickle.loads(row[0])[0]
 
-    def values(self) -> Generator[V, None, None]:
+    def values(self) -> Iterator[V]:  # type: ignore[override]
         """Return an iterator over the values in the dictionary."""
         for row in self._exec_sql("SELECT key_value FROM dict ORDER BY rowid"):
             yield pickle.loads(row[0])[1]
 
-    def items(self) -> Generator[tuple[K, V], None, None]:
+    def items(self) -> Iterator[Tuple[K, V]]:  # type: ignore[override]
         """Return an iterator over the items in the dictionary."""
         for row in self._exec_sql("SELECT key_value FROM dict ORDER BY rowid"):
             yield pickle.loads(row[0])
 
     def nbytes(self) -> int:
         """Return the size of the dictionary in bytes."""
-        return next(self._exec_sql("SELECT page_size * page_count FROM "
-                          "pragma_page_size(), pragma_page_count()"))[0]
+        result, = next(self._exec_sql("SELECT page_size * page_count FROM "
+                                      "pragma_page_size(), pragma_page_count()"))
+        assert isinstance(result, int)
+
+        return result
 
     def __repr__(self) -> str:
         """Return a string representation of the dictionary."""
@@ -648,10 +664,15 @@ class WriteOncePersistentDict(_PersistentDictBase[K, V]):
         :arg in_mem_cache_size: retain an in-memory cache of up to
             *in_mem_cache_size* items (with an LRU replacement policy)
         """
-        _PersistentDictBase.__init__(self, identifier, key_builder,
-                                     container_dir, enable_wal, safe_sync)
+        super().__init__(identifier,
+                         key_builder=key_builder,
+                         container_dir=container_dir,
+                         enable_wal=enable_wal,
+                         safe_sync=safe_sync)
+
         from functools import lru_cache
-        self._fetch = lru_cache(maxsize=in_mem_cache_size)(self._fetch)
+
+        self._fetch = lru_cache(maxsize=in_mem_cache_size)(self._fetch_uncached)
 
     def clear_in_mem_cache(self) -> None:
         """
@@ -682,14 +703,16 @@ class WriteOncePersistentDict(_PersistentDictBase[K, V]):
                     raise ReadOnlyEntryError("WriteOncePersistentDict, "
                                              "tried overwriting key")
 
-    def _fetch(self, keyhash: str) -> Tuple[K, V]:  # pylint:disable=method-hidden
+    def _fetch_uncached(self, keyhash: str) -> Tuple[K, V]:
         # This method is separate from fetch() to allow for LRU caching
         c = self._exec_sql("SELECT key_value FROM dict WHERE keyhash=?",
                               (keyhash,))
         row = c.fetchone()
         if row is None:
             raise KeyError
-        return pickle.loads(row[0])
+
+        key, value = pickle.loads(row[0])
+        return key, value
 
     def fetch(self, key: K) -> V:
         keyhash = self.key_builder(key)
@@ -703,7 +726,7 @@ class WriteOncePersistentDict(_PersistentDictBase[K, V]):
             return value
 
     def clear(self) -> None:
-        _PersistentDictBase.clear(self)
+        super().clear()
         self._fetch.cache_clear()
 
 
@@ -745,8 +768,11 @@ class PersistentDict(_PersistentDictBase[K, V]):
             is faster than the default rollback journal mode, but it is
             not compatible with network filesystems.
         """
-        _PersistentDictBase.__init__(self, identifier, key_builder,
-                                     container_dir, enable_wal, safe_sync)
+        super().__init__(identifier,
+                         key_builder=key_builder,
+                         container_dir=container_dir,
+                         enable_wal=enable_wal,
+                         safe_sync=safe_sync)
 
     def store(self, key: K, value: V, _skip_if_present: bool = False) -> None:
         keyhash = self.key_builder(key)
@@ -768,13 +794,14 @@ class PersistentDict(_PersistentDictBase[K, V]):
 
         stored_key, value = pickle.loads(row[0])
         self._collision_check(key, stored_key)
-        return value
+        return cast(V, value)
 
     def remove(self, key: K) -> None:
         """Remove the entry associated with *key* from the dictionary."""
         keyhash = self.key_builder(key)
 
         def remove_inner() -> None:
+            assert self.conn is not None
             self.conn.execute("BEGIN EXCLUSIVE TRANSACTION")
             try:
                 # This is split into SELECT/DELETE to allow for a collision check

--- a/pytools/stopwatch.py
+++ b/pytools/stopwatch.py
@@ -1,25 +1,28 @@
 import time
+from typing import List, Optional
 
-import pytools
+from pytools import DependentDictionary, Reference
 
 
 class StopWatch:
-    def __init__(self):
-        self.Elapsed = 0.
-        self.LastStart = None
+    def __init__(self) -> None:
+        self.Elapsed = 0.0
+        self.LastStart: Optional[float] = None
 
-    def start(self):
+    def start(self) -> "StopWatch":
         assert self.LastStart is None
+
         self.LastStart = time.time()
         return self
 
-    def stop(self):
+    def stop(self) -> "StopWatch":
         assert self.LastStart is not None
+
         self.Elapsed += time.time() - self.LastStart
         self.LastStart = None
         return self
 
-    def elapsed(self):
+    def elapsed(self) -> float:
         if self.LastStart:
             return time.time() - self.LastStart + self.Elapsed
         else:
@@ -27,19 +30,21 @@ class StopWatch:
 
 
 class Job:
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.Name = name
         self.StopWatch = StopWatch().start()
+
         if self.is_visible():
             print(f"{name}...")
 
-    def done(self):
+    def done(self) -> None:
         elapsed = self.StopWatch.elapsed()
+
         JOB_TIMES[self.Name] += elapsed
         if self.is_visible():
             print(" " * (len(self.Name) + 2), elapsed, "seconds")
 
-    def is_visible(self):
+    def is_visible(self) -> bool:
         if PRINT_JOBS.get():
             return self.Name not in HIDDEN_JOBS
         else:
@@ -47,26 +52,27 @@ class Job:
 
 
 class EtaEstimator:
-    def __init__(self, total_steps):
+    def __init__(self, total_steps: int) -> None:
         self.stopwatch = StopWatch().start()
         self.total_steps = total_steps
         assert total_steps > 0
 
-    def estimate(self, done):
-        fraction_done = done/self.total_steps
+    def estimate(self, done: int) -> Optional[float]:
+        fraction_done = done / self.total_steps
         time_spent = self.stopwatch.elapsed()
-        if fraction_done > 1e-5:
-            return time_spent/fraction_done-time_spent
+
+        if fraction_done > 1.0e-5:
+            return time_spent / fraction_done - time_spent
         else:
             return None
 
 
-def print_job_summary():
-    for key in JOB_TIMES:
-        print(key, " " * (50-len(key)), JOB_TIMES[key])
+def print_job_summary() -> None:
+    for key, value in JOB_TIMES.iteritems():
+        print(key, " " * (50 - len(key)), value)
 
 
-HIDDEN_JOBS = []
-VISIBLE_JOBS = []
-JOB_TIMES = pytools.DependentDictionary(lambda x: 0)
-PRINT_JOBS = pytools.Reference(True)
+HIDDEN_JOBS: List[str] = []
+VISIBLE_JOBS: List[str] = []
+JOB_TIMES = DependentDictionary(lambda x: 0)
+PRINT_JOBS = Reference(True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,12 +20,4 @@ universal = 1
 
 [mypy]
 ignore_missing_imports = True
-
-[mypy-pytools.mpiwrap]
-ignore_errors = True
-
-[mypy-pytools.persistent_dict]
-ignore_errors = True
-
-[mypy-pytools.stopwatch]
-ignore_errors = True
+warn_unused_ignores = true


### PR DESCRIPTION
While playing with #235 and #237 to fix the mypy issues, I had some more random fixes sitting around.

This essentially removes the `ignore_errors = True` in `setup.cfg` for some modules and fixes the errors that popped up. There's a bunch of stuff in `persistent_dict.py` that probably requires a careful look.

cc @matthiasdiener since you typed most of `PersistentDict`.