### PR TITLE
Remove a bunch of unused pylint supressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                python-version: ["3.8", "3.9", "3.x", "pypy3.8"]
+                python-version: ["3.8", "3.9", "3.x", "pypy3.9"]
                 os: [ubuntu-latest, macos-latest]
         steps:
         -   uses: actions/checkout@v4

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -1,7 +1,3 @@
-# pylint:  disable=too-many-lines
-# (Yes, it has a point!)
-
-
 __copyright__ = """
 Copyright (C) 2009-2013 Andreas Kloeckner
 Copyright (C) 2020 Matt Wala
@@ -584,7 +580,7 @@ class DependentDictionary:
 
     def __contains__(self, key):
         try:
-            self[key]  # pylint: disable=pointless-statement
+            self[key]
             return True
         except KeyError:
             return False
@@ -707,7 +703,7 @@ def memoize(*args: F, **kwargs: Any) -> F:
     default_key_func: Optional[Callable[..., Any]]
 
     if use_kw:
-        def default_key_func(*inner_args, **inner_kwargs):  # pylint:disable=function-redefined
+        def default_key_func(*inner_args, **inner_kwargs):
             return inner_args, frozenset(inner_kwargs.items())
     else:
         default_key_func = None
@@ -724,15 +720,15 @@ def memoize(*args: F, **kwargs: Any) -> F:
             def wrapper(*args, **kwargs):
                 key = key_func(*args, **kwargs)
                 try:
-                    return func._memoize_dic[key]  # pylint: disable=protected-access
+                    return func._memoize_dic[key]
                 except AttributeError:
                     # _memoize_dic doesn't exist yet.
                     result = func(*args, **kwargs)
-                    func._memoize_dic = {key: result}  # pylint: disable=protected-access
+                    func._memoize_dic = {key: result}
                     return result
                 except KeyError:
                     result = func(*args, **kwargs)
-                    func._memoize_dic[key] = result  # pylint: disable=protected-access
+                    func._memoize_dic[key] = result
                     return result
 
             from functools import update_wrapper
@@ -743,15 +739,15 @@ def memoize(*args: F, **kwargs: Any) -> F:
         def _decorator(func):
             def wrapper(*args):
                 try:
-                    return func._memoize_dic[args]  # pylint: disable=protected-access
+                    return func._memoize_dic[args]
                 except AttributeError:
                     # _memoize_dic doesn't exist yet.
                     result = func(*args)
-                    func._memoize_dic = {args: result}  # pylint:disable=protected-access
+                    func._memoize_dic = {args: result}
                     return result
                 except KeyError:
                     result = func(*args)
-                    func._memoize_dic[args] = result  # pylint: disable=protected-access
+                    func._memoize_dic[args] = result
                     return result
 
             from functools import update_wrapper
@@ -1808,7 +1804,7 @@ def merge_tables(*tables: Table,
 
 # {{{ histogram formatting
 
-def string_histogram(  # pylint: disable=too-many-arguments,too-many-locals
+def string_histogram(
         iterable, min_value=None, max_value=None,
         bin_count=20, width=70, bin_starts=None, use_unicode=True):
     if bin_starts is None:
@@ -1969,7 +1965,6 @@ class CPyUserInterface:
 
 class StderrToStdout:
     def __enter__(self):
-        # pylint: disable=attribute-defined-outside-init
         self.stderr_backup = sys.stderr
         sys.stderr = sys.stdout
 
@@ -2079,7 +2074,7 @@ def invoke_editor(s, filename="edit.txt", descr="the file"):
 
 # {{{ progress bars
 
-class ProgressBar:  # pylint: disable=too-many-instance-attributes
+class ProgressBar:
     """
     .. automethod:: draw
     .. automethod:: progress
@@ -2353,8 +2348,6 @@ class MinRecursionLimit:
         self.min_rec_limit = min_rec_limit
 
     def __enter__(self):
-        # pylint: disable=attribute-defined-outside-init
-
         self.prev_recursion_limit = sys.getrecursionlimit()
         new_limit = max(self.prev_recursion_limit, self.min_rec_limit)
         sys.setrecursionlimit(new_limit)
@@ -2405,7 +2398,7 @@ def download_from_web_if_not_present(url, local_name=None):
 
 # {{{ find git revisions
 
-def find_git_revision(tree_root):  # pylint: disable=too-many-locals
+def find_git_revision(tree_root):
     # Keep this routine self-contained so that it can be copy-pasted into
     # setup.py.
 
@@ -2545,7 +2538,7 @@ def _log_start_if_long(logger, sleep_duration, done_indicator,
                 sleep_duration)
 
 
-class ProcessLogger:  # pylint: disable=too-many-instance-attributes
+class ProcessLogger:
     """Logs the completion time of a (presumably) lengthy process to :mod:`logging`.
     Only uses a high log level if the process took perceptible time.
 
@@ -2557,7 +2550,7 @@ class ProcessLogger:  # pylint: disable=too-many-instance-attributes
 
     default_noisy_level = logging.INFO
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
             self, logger, description,
             silent_level=None, noisy_level=None, long_threshold_seconds=None):
         self.logger = logger
@@ -2616,7 +2609,7 @@ class ProcessLogger:  # pylint: disable=too-many-instance-attributes
 
         self.timer = ProcessTimer()
 
-    def done(  # pylint: disable=keyword-arg-before-vararg
+    def done(
             self, extra_msg=None, *extra_fmt_args):
         self.timer.done()
         self._done_indicator[0] = True
@@ -2747,7 +2740,7 @@ def resolve_name(name):
     if sys.version_info >= (3, 9):
         # use the official version
         import pkgutil
-        return pkgutil.resolve_name(name)  # pylint: disable=no-member
+        return pkgutil.resolve_name(name)
 
     import importlib
 

--- a/pytools/datatable.py
+++ b/pytools/datatable.py
@@ -190,7 +190,7 @@ class DataTable:
 
         Assumes both tables are sorted ascendingly by the column
         by which they are joined.
-        """  # pylint:disable=too-many-locals,too-many-branches
+        """
 
         def without(indexable: Tuple[str, ...], idx: int) -> Tuple[str, ...]:
             return indexable[:idx] + indexable[idx+1:]
@@ -243,7 +243,7 @@ class DataTable:
                 if outer:
                     this_batch = [(None,) * len(self.column_names)]
 
-            if run_other and not other_over:  # pylint: disable=used-before-assignment
+            if run_other and not other_over:
                 key = other_key
                 while other_row[other_key_idx] == other_key:
                     other_batch.append(other_row)

--- a/pytools/debug.py
+++ b/pytools/debug.py
@@ -55,7 +55,7 @@ class RefDebugQuit(Exception):  # noqa: N818
     pass
 
 
-def refdebug(obj, top_level=True, exclude=()):  # pylint:disable=too-many-locals,too-many-branches,too-many-statements
+def refdebug(obj, top_level=True, exclude=()):
     from types import FrameType
 
     def is_excluded(o):
@@ -154,7 +154,7 @@ def setup_readline():
         try:
             readline.read_history_file(hist_filename)
         except Exception:  # pylint:disable=broad-except
-            # http://docs.python.org/3/howto/pyporting.html#capturing-the-currently-raised-exception  # noqa: E501  pylint:disable=line-too-long
+            # http://docs.python.org/3/howto/pyporting.html#capturing-the-currently-raised-exception  # noqa: E501
             import sys
             e = sys.exc_info()[1]
 

--- a/pytools/graph.py
+++ b/pytools/graph.py
@@ -117,7 +117,7 @@ def reverse_graph(graph: GraphT[NodeT]) -> GraphT[NodeT]:
 
 # {{{ a_star
 
-def a_star(  # pylint: disable=too-many-locals
+def a_star(
         initial_state: NodeT, goal_state: NodeT, neighbor_map: GraphT[NodeT],
         estimate_remaining_cost: Optional[Callable[[NodeT], float]] = None,
         get_step_cost: Callable[[Any, NodeT], float] = lambda x, y: 1
@@ -129,7 +129,6 @@ def a_star(  # pylint: disable=too-many-locals
     from heapq import heappop, heappush
 
     if estimate_remaining_cost is None:
-        # pylint: disable=function-redefined
         def estimate_remaining_cost(x: NodeT) -> float:
             if x != goal_state:
                 return 1

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -234,7 +234,6 @@ class KeyBuilder:
 
         if not isinstance(key, type):
             try:
-                # pylint:disable=protected-access
                 object.__setattr__(key, "_pytools_persistent_hash_digest", digest)
             except AttributeError:
                 pass
@@ -544,7 +543,7 @@ class _PersistentDictBase(Mapping[K, V]):
 
             # This is here so we can step through equality comparison to
             # see what is actually non-equal.
-            stored_key == key  # pylint:disable=pointless-statement  # noqa: B015
+            stored_key == key  # noqa: B015
             raise NoSuchEntryCollisionError(key)
 
     def _exec_sql(self, *args: Any) -> sqlite3.Cursor:

--- a/pytools/prefork.py
+++ b/pytools/prefork.py
@@ -141,7 +141,7 @@ def _fork_server(sock):
         sock.close()
 
     import os
-    os._exit(0)  # pylint:disable=protected-access
+    os._exit(0)
 
 
 class IndirectForker:
@@ -191,7 +191,7 @@ forker = DirectForker()
 
 
 def enable_prefork():
-    global forker  # pylint:disable=global-statement
+    global forker
 
     if isinstance(forker, IndirectForker):
         return

--- a/pytools/spatial_btree.py
+++ b/pytools/spatial_btree.py
@@ -103,7 +103,7 @@ class SpatialBinaryTreeBucket:
             # No subdivisions yet.
             if len(self.elements) > self.max_elements_per_box:
                 # Too many elements. Need to subdivide.
-                self.all_buckets = []  # pylint:disable=attribute-defined-outside-init
+                self.all_buckets = []
                 self.buckets = make_buckets(
                         self.bottom_left, self.top_right,
                         self.all_buckets,

--- a/pytools/test/test_pytools.py
+++ b/pytools/test/test_pytools.py
@@ -50,7 +50,7 @@ def test_memoize_method_clear():
     sc.f()
     assert sc.run_count == 1
 
-    sc.f.clear_cache(sc)  # pylint: disable=no-member
+    sc.f.clear_cache(sc)
 
 
 def test_keyed_memoize_method_with_uncached():
@@ -73,7 +73,7 @@ def test_keyed_memoize_method_with_uncached():
     sc.f(18, 19, z=20)
     assert sc.run_count == 2
 
-    sc.f.clear_cache(sc)  # pylint: disable=no-member
+    sc.f.clear_cache(sc)
 
 
 def test_memoize_in():
@@ -190,7 +190,6 @@ def test_memoize_frozen() -> None:
     c0 = FrozenDataclass(10)
     assert c0.double_value() == 20
 
-    # pylint: disable=no-member
     c0.double_value.clear_cache(c0)  # type: ignore[attr-defined]
 
     # }}}
@@ -213,7 +212,6 @@ def test_memoize_frozen() -> None:
     c1 = FrozenClass(10)
     assert c1.double_value() == 20
 
-    # pylint: disable=no-member
     c1.double_value.clear_cache(c1)  # type: ignore[attr-defined]
 
     # }}}


### PR DESCRIPTION
This removes all the unused suppressions reported by `--enable=I0021`. I'm using pylint 3.2.5 on python 3.12.4, so I imagine not all of these will still pass on the CI, but hopefully some :grin: 

EDIT: That's weird.. I really didn't expect all those `no-member` ones to pass. Oh well!