### PR TITLE
Modernize `pytools.tag`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ classifiers = [
 ]
 dependencies = [
     "platformdirs>=2.2",
-    "typing-extensions>=4; python_version<'3.11'",
+    # for dataclass_transform with frozen_default
+    "typing-extensions>=4; python_version<'3.13'",
     "siphash24>=1.6",
 ]
 

--- a/pytools/test/test_persistent_dict.py
+++ b/pytools/test/test_persistent_dict.py
@@ -82,7 +82,7 @@ def test_persistent_dict_storage_and_lookup() -> None:
 
         keys = [
                 (randrange(2000)-1000, rand_str(), None,
-                 SomeTag(rand_str()),  # type: ignore[call-arg]
+                 SomeTag(rand_str()),
                     frozenset({"abc", 123}))
                 for i in range(20)]
         values = [randrange(2000) for i in range(20)]
@@ -555,7 +555,7 @@ def test_class_hashing() -> None:
     class TagClass3(Tag):
         s: str
 
-    assert (keyb(TagClass3("foo")) == "cf1a33652cc75b9c")  # type: ignore[call-arg]
+    assert (keyb(TagClass3("foo")) == "cf1a33652cc75b9c")
 
 
 def test_dataclass_hashing() -> None:

--- a/run-mypy.sh
+++ b/run-mypy.sh
@@ -4,4 +4,7 @@ set -ex
 
 mypy --show-error-codes pytools
 
-mypy --strict --follow-imports=silent pytools/datatable.py pytools/persistent_dict.py
+mypy --strict --follow-imports=silent \
+    pytools/tag.py \
+    pytools/datatable.py \
+    pytools/persistent_dict.py


### PR DESCRIPTION
- Better type annotations
- Remove IgnoredForEqualityTag
- Have tag_dataclass use dataclass_transform
- Drop fallback from ._with_new_tags to .copy
- Allow Taggable.tags to be a read-only attribute
- Enable strict typing for pytools.tag