### PR TITLE
persistent_dict: make siphash24 optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
                 python-version: '3.x'
         -   name: "Main Script"
             run: |
-                EXTRA_INSTALL="numpy"
+                EXTRA_INSTALL="numpy siphash24"
                 curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/prepare-and-run-mypy.sh
                 . ./prepare-and-run-mypy.sh python3 mypy
 
@@ -89,7 +89,7 @@ jobs:
                 # AK, 2020-12-13
                 rm pytools/mpiwrap.py
 
-                EXTRA_INSTALL="numpy frozendict immutabledict orderedsets constantdict immutables pyrsistent attrs"
+                EXTRA_INSTALL="numpy frozendict immutabledict orderedsets constantdict immutables pyrsistent attrs siphash24"
                 curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project.sh
                 . ./build-and-test-py-project.sh
 
@@ -104,6 +104,7 @@ jobs:
                 python-version: '3.x'
         -   name: "Main Script"
             run: |
+                EXTRA_INSTALL="siphash24"
                 rm pytools/{convergence,spatial_btree,obj_array,mpiwrap}.py
                 curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project.sh
                 . ./build-and-test-py-project.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "platformdirs>=2.2",
     # for dataclass_transform with frozen_default
     "typing-extensions>=4; python_version<'3.13'",
-    "siphash24>=1.6",
 ]
 
 [project.optional-dependencies]
@@ -45,6 +44,9 @@ test = [
     "mypy",
     "pytest",
     "ruff",
+]
+siphash = [
+    "siphash24>=1.6",
 ]
 
 [project.urls]


### PR DESCRIPTION
From #242:

> I don't know how much of a bottleneck the hash computation is in mirgecom compiles, but at the same time, I can't think of a good reason to not do this.

I maintain `pytools` and `pyopencl` on Void Linux and, as long as the hash interface is equivalent, making `siphash24` optional will slightly reduce the maintenance burden of carrying these packages alongside the rest of the numerical stack.