### PR TITLE
pyproject: move typos.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,8 @@ lines-after-imports = 2
 [tool.mypy]
 ignore_missing_imports = true
 warn_unused_ignores = true
+
+[tool.typos.default]
+extend-ignore-re = [
+  "(?Rm)^.*(#|//)\\s*spellchecker:\\s*disable-line$"
+]

--- a/typos.toml
+++ b/typos.toml
@@ -1,4 +1,0 @@
-[default]
-extend-ignore-re = [
-  "(?Rm)^.*(#|//)\\s*spellchecker:\\s*disable-line$"
-]


### PR DESCRIPTION
Moves the `typos.toml` config and removes the configuration file.