### PR TITLE
tag: only import typing_extensions when TYPE_CHECKING

### DIFF
--- a/doc/upload-docs.sh
+++ b/doc/upload-docs.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-rsync --verbose --archive --delete _build/html/* doc-upload:doc/pytools
+rsync --verbose --archive --delete _build/html/ doc-upload:doc/pytools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,8 @@ lines-after-imports = 2
 python_version = "3.8"
 ignore_missing_imports = true
 warn_unused_ignores = true
+# TODO: enable this at some point
+# check_untyped_defs = true
 
 [tool.typos.default]
 extend-ignore-re = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ known-local-folder = [
 lines-after-imports = 2
 
 [tool.mypy]
+python_version = "3.8"
 ignore_missing_imports = true
 warn_unused_ignores = true
 

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -32,6 +32,7 @@ import sys
 from functools import reduce, wraps
 from sys import intern
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
@@ -52,15 +53,21 @@ from typing import (
 )
 
 
-try:
-    from typing import Concatenate, SupportsIndex
-except ImportError:
-    from typing_extensions import Concatenate, SupportsIndex
+if TYPE_CHECKING:
+    # NOTE: mypy seems to be confused by the `try.. except` below when called with
+    #   python -m mypy --python-version 3.8 ...
+    # see https://github.com/python/mypy/issues/14220
+    from typing_extensions import Concatenate, ParamSpec, SupportsIndex
+else:
+    try:
+        from typing import Concatenate, SupportsIndex
+    except ImportError:
+        from typing_extensions import Concatenate, SupportsIndex
 
-try:
-    from typing import ParamSpec
-except ImportError:
-    from typing_extensions import ParamSpec  # type: ignore[assignment]
+    try:
+        from typing import ParamSpec
+    except ImportError:
+        from typing_extensions import ParamSpec  # type: ignore[assignment]
 
 
 # These are deprecated and will go away in 2022.

--- a/pytools/convergence.py
+++ b/pytools/convergence.py
@@ -75,7 +75,7 @@ class EOCRecorder:
             gliding_mean = size
 
         data_points = size - gliding_mean + 1
-        result = np.zeros((data_points, 2), float)
+        result: np.ndarray = np.zeros((data_points, 2), float)
         for i in range(data_points):
             result[i, 0], result[i, 1] = estimate_order_of_convergence(
                 abscissae[i:i+gliding_mean], errors[i:i+gliding_mean])

--- a/pytools/graph.py
+++ b/pytools/graph.py
@@ -66,6 +66,7 @@ Type Variables Used
 
 from dataclasses import dataclass
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Collection,
@@ -83,10 +84,16 @@ from typing import (
 )
 
 
-try:
-    from typing import TypeAlias
-except ImportError:
+if TYPE_CHECKING:
+    # NOTE: mypy seems to be confused by the `try.. except` below when called with
+    #   python -m mypy --python-version 3.8 ...
+    # see https://github.com/python/mypy/issues/14220
     from typing_extensions import TypeAlias
+else:
+    try:
+        from typing import TypeAlias
+    except ImportError:
+        from typing_extensions import TypeAlias
 
 
 NodeT = TypeVar("NodeT", bound=Hashable)

--- a/pytools/tag.py
+++ b/pytools/tag.py
@@ -40,10 +40,16 @@ from typing import (
 from warnings import warn
 
 
-try:
-    from typing import Self, dataclass_transform
-except ImportError:
+if TYPE_CHECKING:
+    # NOTE: mypy seems to be confused by the `try.. except` below when called with
+    #   python -m mypy --python-version 3.8 ...
+    # see https://github.com/python/mypy/issues/14220
     from typing_extensions import Self, dataclass_transform
+else:
+    try:
+        from typing import Self, dataclass_transform
+    except ImportError:
+        from typing_extensions import Self, dataclass_transform
 
 from pytools import memoize, memoize_method
 

--- a/pytools/test/test_pytools.py
+++ b/pytools/test/test_pytools.py
@@ -497,7 +497,7 @@ def test_obj_array_vectorize(c=1):
 # }}}
 
 
-def test_tag():
+def test_tag() -> None:
     from pytools.tag import (
         NonUniqueTagError,
         Tag,
@@ -552,7 +552,7 @@ def test_tag():
     # a subclass of Tag
     with pytest.raises(TypeError):
         check_tag_uniqueness(frozenset((
-            "I am not a tag", best_in_show_ribbon,
+            "I am not a tag", best_in_show_ribbon,  # type: ignore[arg-type]
             blue_ribbon, red_ribbon)))
 
     # Test that instantiation succeeds if there are multiple instances
@@ -583,7 +583,7 @@ def test_tag():
 
     # Test that tagged() fails if tags are not a FrozenSet of Tags
     with pytest.raises(TypeError):
-        t1.tagged(tags=frozenset((1,)))
+        t1.tagged(tags=frozenset((1,)))  # type: ignore[arg-type]
 
     # Test without_tags() function
     t4 = t2.without_tags(red_ribbon)


### PR DESCRIPTION
Seems to fix the issues from https://github.com/inducer/arraycontext/pull/275