### PR TITLE
KeyBuilder: use system byteorder to match numpy

### DIFF
--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -174,6 +174,12 @@ class KeyBuilder:
         may stop working as early as 2022.
 
         .. versionadded:: 2021.2
+
+    .. note::
+
+        Some key-building uses system byte order, so the built keys may not match
+        across different systems. It would be desirable to fix this, but this is
+        not yet done.
     """
 
     # this exists so that we can (conceivably) switch algorithms at some point
@@ -280,7 +286,10 @@ class KeyBuilder:
         sz = 8
         while True:
             try:
-                key_hash.update(key.to_bytes(sz, byteorder="little", signed=True))
+                # Must match system byte order so that numpy and this
+                # generate the same string of bytes.
+                # https://github.com/inducer/pytools/issues/259
+                key_hash.update(key.to_bytes(sz, byteorder=sys.byteorder, signed=True))
                 return
             except OverflowError:
                 sz *= 2


### PR DESCRIPTION
Closes gh-259