### PR TITLE
Unconditionally depend on `typing-extensions`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "platformdirs>=2.2",
     # for dataclass_transform with frozen_default
-    "typing-extensions>=4; python_version<'3.13'",
+    "typing-extensions>=4",
 ]
 
 [project.optional-dependencies]

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -32,7 +32,6 @@ import sys
 from functools import reduce, wraps
 from sys import intern
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
@@ -52,22 +51,7 @@ from typing import (
     Union,
 )
 
-
-if TYPE_CHECKING:
-    # NOTE: mypy seems to be confused by the `try.. except` below when called with
-    #   python -m mypy --python-version 3.8 ...
-    # see https://github.com/python/mypy/issues/14220
-    from typing_extensions import Concatenate, ParamSpec, SupportsIndex
-else:
-    try:
-        from typing import Concatenate, SupportsIndex
-    except ImportError:
-        from typing_extensions import Concatenate, SupportsIndex
-
-    try:
-        from typing import ParamSpec
-    except ImportError:
-        from typing_extensions import ParamSpec  # type: ignore[assignment]
+from typing_extensions import Concatenate, ParamSpec, SupportsIndex
 
 
 # These are deprecated and will go away in 2022.

--- a/pytools/graph.py
+++ b/pytools/graph.py
@@ -69,7 +69,6 @@ Type Variables Used
 
 from dataclasses import dataclass
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Collection,
@@ -89,17 +88,7 @@ from typing import (
     TypeVar,
 )
 
-
-if TYPE_CHECKING:
-    # NOTE: mypy seems to be confused by the `try.. except` below when called with
-    #   python -m mypy --python-version 3.8 ...
-    # see https://github.com/python/mypy/issues/14220
-    from typing_extensions import TypeAlias
-else:
-    try:
-        from typing import TypeAlias
-    except ImportError:
-        from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias
 
 
 NodeT = TypeVar("NodeT", bound=Hashable)

--- a/pytools/tag.py
+++ b/pytools/tag.py
@@ -39,17 +39,7 @@ from typing import (
 )
 from warnings import warn
 
-
-if TYPE_CHECKING:
-    # NOTE: mypy seems to be confused by the `try.. except` below when called with
-    #   python -m mypy --python-version 3.8 ...
-    # see https://github.com/python/mypy/issues/14220
-    from typing_extensions import Self, dataclass_transform
-else:
-    try:
-        from typing import Self, dataclass_transform
-    except ImportError:
-        from typing_extensions import Self, dataclass_transform
+from typing_extensions import Self, dataclass_transform
 
 from pytools import memoize, memoize_method
 


### PR DESCRIPTION
Conditional dependencies are too bug-prone, plus the catchy imports are super verbose.