### PR TITLE
mypy: add strict typing to prefork

### DIFF
--- a/run-mypy.sh
+++ b/run-mypy.sh
@@ -2,10 +2,11 @@
 
 set -ex
 
-mypy pytools
+python -m mypy pytools
 
-mypy --strict --follow-imports=silent \
-    pytools/tag.py \
-    pytools/graph.py \
+python -m mypy --strict --follow-imports=silent \
     pytools/datatable.py \
-    pytools/persistent_dict.py
+    pytools/graph.py \
+    pytools/persistent_dict.py \
+    pytools/prefork.py \
+    pytools/tag.py \


### PR DESCRIPTION
Mostly straightforward, but the socket communication is pretty much ignored for typing.

Don't quite recall, but I think some other package required typing `call_capture_output`, so went ahead and typed the whole thing.