### PR TITLE
Allow `get_reachable_nodes` to be restricted to partitions

### DIFF
--- a/pytools/graph.py
+++ b/pytools/graph.py
@@ -568,14 +568,21 @@ def undirected_graph_from_edges(
 def get_reachable_nodes(
         undirected_graph: GraphT[NodeT],
         source_node: NodeT,
-        exclude_nodes: Optional[set[NodeT]] = None) -> frozenset[NodeT]:
+        exclude_nodes: Optional[Collection[NodeT]] = None) -> frozenset[NodeT]:
     """
     Returns a :class:`frozenset` of all nodes in *undirected_graph* that are
-    reachable from *source_node*. Reachability of nodes from *source_node* can
-    be restricted by supplying a set of nodes to be excluded from consideration.
-    Effectively, this amounts to traversing partitions of *undirected_graph*
-    with partition points defined by *exclude_nodes*.
+    reachable from *source_node*.
+
+    If any node from *exclude_nodes* lies on a path between *source_node* and
+    some other node :math:`u` in *undirected_graph* and there are no other
+    viable paths, then :math:`u` is considered not reachable from *source_node*.
+
+    In the case where *source_node* is in *exclude_nodes*, then no node is
+    reachable from *source_node*, so an empty :class:`frozenset` is returned.
     """
+    if exclude_nodes is not None and source_node in exclude_nodes:
+        return frozenset()
+
     nodes_visited: set[NodeT] = set()
     reachable_nodes: set[NodeT] = set()
     nodes_to_visit = {source_node}
@@ -587,17 +594,13 @@ def get_reachable_nodes(
         current_node = nodes_to_visit.pop()
         nodes_visited.add(current_node)
 
-        if current_node in exclude_nodes:
-            continue
-
         reachable_nodes.add(current_node)
 
-        new_nodes_to_visit = set()
-        for node in undirected_graph[current_node]:
-            if node not in nodes_visited and node not in exclude_nodes:
-                new_nodes_to_visit.add(node)
-
-        nodes_to_visit.update(new_nodes_to_visit)
+        neighbors = undirected_graph[current_node]
+        nodes_to_visit.update({
+            node for node in neighbors
+            if node not in nodes_visited and node not in exclude_nodes
+        })
 
     return frozenset(reachable_nodes)
 

--- a/pytools/test/test_graph_tools.py
+++ b/pytools/test/test_graph_tools.py
@@ -435,29 +435,35 @@ def test_propagation_graph_tools():
         get_reachable_nodes,
         undirected_graph_from_edges,
     )
-
     vars = {"a", "b", "c", "d", "e", "f", "g"}
 
-    constraints = [
+    constraints = {
         ("a", "b"),
-        ("a", "d"),
-        ("c", "d"),
-        ("e", "f"),
+        ("b", "c"),
+        ("b", "d"),
+        ("c", "e"),
+        ("d", "f"),
+        ("e", "g"),
+        ("g", "f"),
         ("f", "g")
-    ]
+    }
 
     all_reachable_nodes = {
-        "a": frozenset({"a", "b", "c", "d"}),
-        "b": frozenset({"a", "b", "c", "d"}),
-        "c": frozenset({"a", "b", "c", "d"}),
+        "a": frozenset({"a", "b"}),
+        "b": frozenset({"a", "b"}),
+        "c": frozenset(),
+        "d": frozenset(),
         "e": frozenset({"e", "f", "g"}),
         "f": frozenset({"e", "f", "g"}),
         "g": frozenset({"e", "f", "g"})
     }
 
+    exclude_nodes = {"d", "c"}
     propagation_graph = undirected_graph_from_edges(constraints)
+
     assert (
-        all_reachable_nodes[var] == get_reachable_nodes(propagation_graph, var)
+        all_reachable_nodes[var] == get_reachable_nodes(propagation_graph, var,
+                                                        exclude_nodes)
         for var in vars
     )
 


### PR DESCRIPTION
Updates `get_reachable_nodes` to take an optional set containing nodes that should be ignored (effectively partition points) in an undirected graph. Also updates the corresponding test to account for this new feature.