### PR TITLE
fix numpy scalar hash for bigendian

### DIFF
--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -68,7 +68,7 @@ else:
     _HAS_ATTRS = True
 
 
-IS_BIGENDIAN = sys.byteorder == "big"
+_IS_BIGENDIAN = sys.byteorder == "big"
 
 
 logger = logging.getLogger(__name__)
@@ -336,7 +336,7 @@ class KeyBuilder:
         elif hasattr(np, "float128") and key.dtype == np.dtype("float128"):
             key_hash.update(repr(float(key)).encode("utf8"))
         else:
-            if IS_BIGENDIAN:
+            if _IS_BIGENDIAN:
                 key_hash.update(np.array(key).byteswap().tobytes())
             else:
                 key_hash.update(np.array(key).tobytes())

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -219,6 +219,8 @@ class KeyBuilder:
                         # Non-numpy scalars are handled above in the try block.
                         method = self.update_for_numpy_scalar
 
+                    # numpy arrays are mutable so they are not handled in KeyBuilder
+
                 if method is None:
                     if issubclass(tp, Enum):
                         method = self.update_for_enum
@@ -324,6 +326,8 @@ class KeyBuilder:
 
     def update_for_numpy_scalar(self, key_hash: Hash, key: Any) -> None:
         import numpy as np
+        if sys.byteorder == "big":
+            key = key.byteswap()
         if hasattr(np, "complex256") and key.dtype == np.dtype("complex256"):
             key_hash.update(repr(complex(key)).encode("utf8"))
         elif hasattr(np, "float128") and key.dtype == np.dtype("float128"):

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -68,6 +68,7 @@ else:
     _HAS_ATTRS = True
 
 
+# Used to speed up the comparison in update_for_numpy_scalar and for mock testing
 _IS_BIGENDIAN = sys.byteorder == "big"
 
 
@@ -331,6 +332,9 @@ class KeyBuilder:
 
     def update_for_numpy_scalar(self, key_hash: Hash, key: Any) -> None:
         import numpy as np
+
+        # tobytes() of np.complex256 and np.float128 are non-deterministic,
+        # so we need to use their repr() instead.
         if hasattr(np, "complex256") and key.dtype == np.dtype("complex256"):
             key_hash.update(repr(complex(key)).encode("utf8"))
         elif hasattr(np, "float128") and key.dtype == np.dtype("float128"):

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -68,6 +68,9 @@ else:
     _HAS_ATTRS = True
 
 
+IS_BIGENDIAN = sys.byteorder == "big"
+
+
 logger = logging.getLogger(__name__)
 
 # NOTE: not always available so they get hardcoded here
@@ -271,6 +274,8 @@ class KeyBuilder:
 
     def update_for_int(self, key_hash: Hash, key: int) -> None:
         sz = 8
+        # Note: this must match the hash for numpy integers, since
+        # np.int64(1) == 1
         while True:
             try:
                 key_hash.update(key.to_bytes(sz, byteorder="little", signed=True))
@@ -326,7 +331,7 @@ class KeyBuilder:
 
     def update_for_numpy_scalar(self, key_hash: Hash, key: Any) -> None:
         import numpy as np
-        if sys.byteorder == "big":
+        if IS_BIGENDIAN:
             key = key.byteswap()
         if hasattr(np, "complex256") and key.dtype == np.dtype("complex256"):
             key_hash.update(repr(complex(key)).encode("utf8"))

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -163,12 +163,6 @@ class KeyBuilder:
         may stop working as early as 2022.
 
         .. versionadded:: 2021.2
-
-    .. note::
-
-        Some key-building uses system byte order, so the built keys may not match
-        across different systems. It would be desirable to fix this, but this is
-        not yet done.
     """
 
     # this exists so that we can (conceivably) switch algorithms at some point
@@ -277,10 +271,7 @@ class KeyBuilder:
         sz = 8
         while True:
             try:
-                # Must match system byte order so that numpy and this
-                # generate the same string of bytes.
-                # https://github.com/inducer/pytools/issues/259
-                key_hash.update(key.to_bytes(sz, byteorder=sys.byteorder, signed=True))
+                key_hash.update(key.to_bytes(sz, byteorder="little", signed=True))
                 return
             except OverflowError:
                 sz *= 2

--- a/pytools/persistent_dict.py
+++ b/pytools/persistent_dict.py
@@ -331,14 +331,15 @@ class KeyBuilder:
 
     def update_for_numpy_scalar(self, key_hash: Hash, key: Any) -> None:
         import numpy as np
-        if IS_BIGENDIAN:
-            key = key.byteswap()
         if hasattr(np, "complex256") and key.dtype == np.dtype("complex256"):
             key_hash.update(repr(complex(key)).encode("utf8"))
         elif hasattr(np, "float128") and key.dtype == np.dtype("float128"):
             key_hash.update(repr(float(key)).encode("utf8"))
         else:
-            key_hash.update(np.array(key).tobytes())
+            if IS_BIGENDIAN:
+                key_hash.update(np.array(key).byteswap().tobytes())
+            else:
+                key_hash.update(np.array(key).tobytes())
 
     def update_for_dataclass(self, key_hash: Hash, key: Any) -> None:
         self.rec(key_hash, f"{type(key).__qualname__}.{type(key).__name__}")

--- a/pytools/test/test_persistent_dict.py
+++ b/pytools/test/test_persistent_dict.py
@@ -482,14 +482,11 @@ def test_scalar_hashing() -> None:
     h_int64 = keyb(np.int64(1))
 
     import unittest.mock
-    with unittest.mock.patch("pytools.persistent_dict.IS_BIGENDIAN", True):
-        # Very crude big-endian test. Apparently, there is no way to
-        # create a numpy scalar (not an np.array!) of a specific byte order.
-        if sys.byteorder == "big":
-            # no need to swap
-            be_val = np.int64(1)
-        else:
-            be_val = np.int64(1).byteswap()
+
+    from pytools.persistent_dict import IS_BIGENDIAN
+    with unittest.mock.patch("pytools.persistent_dict.IS_BIGENDIAN", not IS_BIGENDIAN):
+        # Very crude test that the other endianness works as well.
+        be_val = np.int64(1).byteswap()
         assert h_int64 == keyb(be_val)
 
 

--- a/pytools/test/test_persistent_dict.py
+++ b/pytools/test/test_persistent_dict.py
@@ -479,6 +479,19 @@ def test_scalar_hashing() -> None:
         assert keyb(np.complex256(1.1+2.2j)) == keyb(np.complex256(1.1+2.2j))
     assert keyb(np.clongdouble(1.1+2.2j)) == keyb(np.clongdouble(1.1+2.2j))
 
+    h_int64 = keyb(np.int64(1))
+
+    import unittest.mock
+    with unittest.mock.patch("pytools.persistent_dict.IS_BIGENDIAN", True):
+        # Very crude big-endian test. Apparently, there is no way to
+        # create a numpy scalar (not an np.array!) of a specific byte order.
+        if sys.byteorder == "big":
+            # no need to swap
+            be_val = np.int64(1)
+        else:
+            be_val = np.int64(1).byteswap()
+        assert h_int64 == keyb(be_val)
+
 
 @pytest.mark.parametrize("dict_impl", ("immutabledict", "frozendict",
                                        "constantdict",

--- a/pytools/test/test_persistent_dict.py
+++ b/pytools/test/test_persistent_dict.py
@@ -483,8 +483,9 @@ def test_scalar_hashing() -> None:
 
     import unittest.mock
 
-    from pytools.persistent_dict import IS_BIGENDIAN
-    with unittest.mock.patch("pytools.persistent_dict.IS_BIGENDIAN", not IS_BIGENDIAN):
+    from pytools.persistent_dict import _IS_BIGENDIAN
+    with unittest.mock.patch("pytools.persistent_dict._IS_BIGENDIAN",
+                             not _IS_BIGENDIAN):
         # Very crude test that the other endianness works as well.
         be_val = np.int64(1).byteswap()
         assert h_int64 == keyb(be_val)


### PR DESCRIPTION
Fixes #262. Followup of #259, #260, #261.

Reverts #260.
Closes #261.

TODO:
- [x] add a test with mock

_Please squash_