### PR TITLE
Update links for badges in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,10 +4,10 @@ Pytools: Lots of Little Utilities
 .. image:: https://gitlab.tiker.net/inducer/pytools/badges/main/pipeline.svg
     :alt: Gitlab Build Status
     :target: https://gitlab.tiker.net/inducer/pytools/commits/main
-.. image:: https://github.com/inducer/pytools/workflows/CI/badge.svg?branch=main
+.. image:: https://github.com/inducer/pytools/actions/workflows/ci.yml/badge.svg
     :alt: Github Build Status
-    :target: https://github.com/inducer/pytools/actions?query=branch%3Amain+workflow%3ACI
-.. image:: https://badge.fury.io/py/pytools.png
+    :target: https://github.com/inducer/pytools/actions/workflows/ci.yml
+.. image:: https://badge.fury.io/py/pytools.svg
     :alt: Python Package Index Release Page
     :target: https://pypi.org/project/pytools/
 .. image:: https://zenodo.org/badge/1575270.svg
@@ -19,18 +19,16 @@ library. This is mainly a dependency of my other software packages, and is
 probably of little interest to you unless you use those. If you're curious
 nonetheless, here's what's on offer:
 
-* A ton of small tool functions such as `len_iterable`, `argmin`,
+* A ton of small tool functions such as ``len_iterable``, ``argmin``,
   tuple generation, permutation generation, ASCII table pretty printing,
-  GvR's monkeypatch_xxx() hack, the elusive `flatten`, and much more.
-* Batch job submission, `pytools.batchjob`.
-* A lexer, `pytools.lex`.
-* A persistent key-value store, `pytools.persistent_dict`.
+  GvR's ``monkeypatch_xxx()`` hack, the elusive ``flatten``, and much more.
+* Batch job submission, ``pytools.batchjob``.
+* A lexer, ``pytools.lex``.
+* A persistent key-value store, ``pytools.persistent_dict``.
 
 Links:
 
-* `Documentation <https://documen.tician.de/pytools>`_
-
-* `Github <https://github.com/inducer/pytools>`_
-
+* `Documentation <https://documen.tician.de/pytools>`__
+* `Github <https://github.com/inducer/pytools>`__
 * ``pytools.log`` has been spun out into a separate project,
   `logpyle <https://github.com/illinois-ceesd/logpyle>`__.


### PR DESCRIPTION
Forgot to push this yesterday. It updates the link for the CI badge so that it doesn't say "no status" :grin: