### PR TITLE
Use select vs extend-select in ruff config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,23 +106,6 @@ jobs:
                 curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project.sh
                 . ./build-and-test-py-project.sh
 
-    #examples:
-    #    name: Examples Py3
-    #    runs-on: ubuntu-latest
-    #    steps:
-    #    -   uses: actions/checkout@v6
-    #    -
-    #        uses: actions/setup-python@v6
-    #        with:
-    #            python-version: '3.x'
-    #    -   name: "Main Script"
-    #        run: |
-    #            EXTRA_INSTALL="numpy pymbolic"
-    #            curl -L -O https://tiker.net/ci-support-v0
-    #            . ./ci-support-v0
-    #            build_py_project_in_venv
-    #            run_examples
-
     downstream_tests:
         strategy:
             matrix:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,18 +29,6 @@ Pytest without Numpy:
     reports:
       junit: test/pytest.xml
 
-# Examples:
-#   script: |
-#     EXTRA_INSTALL="numpy pymbolic"
-#     curl -L -O https://tiker.net/ci-support-v0
-#     . ./ci-support-v0
-#     build_py_project_in_venv
-#     run_examples
-#   tags:
-#   - python3
-#   except:
-#   - tags
-
 Ruff:
   script: |
     pipx install ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ exclude = [
 preview = true
 
 [tool.ruff.lint]
-extend-select = [
+select = [
     "B",   # flake8-bugbear
     "C",   # flake8-comprehensions
     "E",   # pycodestyle

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -508,11 +508,8 @@ class RecordWithoutPickling:
         fields.update(new_fields)
 
     def __getattr__(self, name):
-        # This method is implemented to avoid pylint 'no-member' errors for
-        # attribute access.
         raise AttributeError(
-                "'{}' object has no attribute '{}'".format(
-                    self.__class__.__name__, name))
+                f"'{self.__class__.__name__}' object has no attribute '{name}'")
 
 
 class Record(RecordWithoutPickling):

--- a/pytools/__init__.py
+++ b/pytools/__init__.py
@@ -629,9 +629,10 @@ class DependentDictionary(Generic[T, R]):
     def __contains__(self, key: T) -> bool:
         try:
             self[key]
-            return True
         except KeyError:
             return False
+        else:
+            return True
 
     def __getitem__(self, key: T) -> R:
         try:
@@ -1609,7 +1610,7 @@ def generate_all_integer_tuples_below(
         n, length, least_abs))
 
 
-class _ConcatenableSequence(Generic[T_co], Protocol):
+class _ConcatenableSequence(Protocol, Generic[T_co]):
     """
     A protocol that supports the following:
 
@@ -2185,9 +2186,7 @@ def invoke_editor(s: str, filename: str = "edit.txt", descr: str = "the file"):
                 "dropped directly into an editor next time.)")
         input(f"Edit {descr} at {full_path} now, then hit [Enter]:")
 
-    result = full_path.read_text()
-
-    return result
+    return full_path.read_text()
 
 # }}}
 

--- a/pytools/debug.py
+++ b/pytools/debug.py
@@ -124,8 +124,8 @@ def refdebug(obj, top_level=True, exclude=()):
                 print("type expression, obj is your object:")
                 expr_str = input()
                 try:
-                    res = eval(expr_str, {"obj": r})  # pylint:disable=eval-used
-                except Exception:  # pylint:disable=broad-except
+                    res = eval(expr_str, {"obj": r})
+                except Exception:
                     from traceback import print_exc
                     print_exc()
                 print(res)
@@ -156,7 +156,7 @@ def setup_readline():
     if exists(hist_filename):
         try:
             readline.read_history_file(hist_filename)
-        except Exception:  # pylint:disable=broad-except
+        except Exception:
             # http://docs.python.org/3/howto/pyporting.html#capturing-the-currently-raised-exception
             import sys
             e = sys.exc_info()[1]

--- a/pytools/mpiwrap.py
+++ b/pytools/mpiwrap.py
@@ -1,14 +1,14 @@
 """See pytools.prefork for this module's reason for being."""
 from __future__ import annotations
 
-import mpi4py.rc  # pylint:disable=import-error
+import mpi4py.rc
 
 
 mpi4py.rc.initialize = False
 
-from mpi4py.MPI import *  # noqa: F403 pylint:disable=wildcard-import,wrong-import-position
+from mpi4py.MPI import *  # noqa: F403
 
-import pytools.prefork  # pylint:disable=wrong-import-position
+import pytools.prefork
 
 
 pytools.prefork.enable_prefork()

--- a/pytools/prefork.py
+++ b/pytools/prefork.py
@@ -194,7 +194,7 @@ def _fork_server(sock: socket.socket) -> None:
             try:
                 result = funcs[func_name](*args, **kwargs)
             # FIXME: Is catching all exceptions the right course of action?
-            except Exception as e:  # pylint:disable=broad-except
+            except Exception as e:
                 _send_packet(sock, ("exception", e))
             else:
                 _send_packet(sock, ("ok", result))

--- a/pytools/test/test_dataclasses.py
+++ b/pytools/test/test_dataclasses.py
@@ -53,13 +53,13 @@ def test_opt_frozen_dataclass() -> None:
     else:
         a.x = 2
 
-    assert a.__dataclass_params__.frozen is __debug__  # pylint: disable=no-member
+    assert a.__dataclass_params__.frozen is __debug__
 
     # }}}
 
     with pytest.raises(TypeError):
         # Can't specify frozen parameter
-        @opt_frozen_dataclass(frozen=False)  # pylint: disable=unexpected-keyword-arg
+        @opt_frozen_dataclass(frozen=False)
         class B:
             x: int
 

--- a/pytools/test/test_pytools.py
+++ b/pytools/test/test_pytools.py
@@ -416,7 +416,7 @@ class FakeArray:
 def test_make_obj_array_iteration():
     pytest.importorskip("numpy")
 
-    import pytools.obj_array as obj_array
+    from pytools import obj_array
     obj_array.new_1d([FakeArray()])
 
     assert FakeArray.nopes == 0, FakeArray.nopes
@@ -430,7 +430,7 @@ def test_obj_array_vectorize(c=1):
     np = pytest.importorskip("numpy")
     la = pytest.importorskip("numpy.linalg")
 
-    import pytools.obj_array as obj_array
+    from pytools import obj_array
 
     # {{{ functions
 


### PR DESCRIPTION
Ruff just enabled pretty much everything in preview mode: https://github.com/astral-sh/ruff/releases/tag/0.15.2
This switches to `select` (from `extend-select`) so we only run the rules in the config.