### PR TITLE
Fix new pyright errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
                 python-version: '3.x'
         -   name: "Main Script"
             run: |
-                EXTRA_INSTALL="basedpyright numpy attrs orderedsets pytest mpi4py matplotlib optype"
+                EXTRA_INSTALL="basedpyright numpy attrs orderedsets pytest mpi4py matplotlib optype<0.18"
 
                 sudo apt update
                 sudo apt -y install libopenmpi-dev
@@ -150,7 +150,7 @@ jobs:
                 python-version: '3.x'
         -   name: "Main Script"
             run: |
-                EXTRA_INSTALL="numpy optype"
+                EXTRA_INSTALL="numpy optype<0.18"
                 curl -L -O https://tiker.net/ci-support-v0
                 . ci-support-v0
                 build_py_project_in_venv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,7 +52,7 @@ Ruff:
 
 Documentation:
   script: |
-    EXTRA_INSTALL="numpy siphash24 optype"
+    EXTRA_INSTALL="numpy siphash24 optype<0.18"
     curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/build-docs.sh
     . ./build-docs.sh
   tags:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ numpy = [
 ]
 test = [
     "basedpyright",
-    "optype",
+    # NOTE: 0.18 requires Python 3.12
+    "optype<0.18",
     "pytest",
     "ruff",
 ]


### PR DESCRIPTION
The new `optype==0.18.0` requires Python 3.12 for typing (mostly seems to use `typing.TypeAliasType` now). This bumps the version in `pyproject.toml` for `basedpyright` and fixes some small errors.

From what I could tell, a bunch of other projects using `optype` also have the same issues :\ 